### PR TITLE
feat: log failed tracks and identify Atmos downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ tidekeeper
 tidekeeper -l "https://tidal.com/browse/track/70973230"
 ```
 
+Dolby Atmos downloads are opt-in:
+
+```bash
+tidekeeper -q Atmos
+tidekeeper -l "https://tidal.com/browse/album/123456"
+```
+
+When an Atmos stream is downloaded, the default track filename gets a
+`[Dolby Atmos]` suffix. Custom track filename formats can also use
+`{StreamQuality}` and `{Codec}`, for example:
+
+```text
+{TrackNumber} - {ArtistName} - {TrackTitle} [{StreamQuality}] [{Codec}]
+```
+
+If a track download fails, Tidekeeper appends it to `failed-tracks.txt` in the
+download folder. The file keeps comments with the title and reason, followed by
+a plain TIDAL track URL. Retry those tracks later with:
+
+```bash
+tidekeeper -l "/path/to/downloads/failed-tracks.txt"
+```
+
 Legacy command:
 
 ```bash

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -1,10 +1,12 @@
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
 import tidal_dl
-from tidal_dl import apiKey, events, paths
+from tidal_dl import apiKey, download, events, paths
 from tidal_dl.enums import AudioQuality, Type, VideoQuality
 from tidal_dl.model import StreamUrl
 from tidal_dl.tidal import TidalAPI
@@ -71,9 +73,11 @@ class CliAuthPathRegressionTests(unittest.TestCase):
     def _stream(self):
         stream = StreamUrl()
         stream.url = "https://example.invalid/audio.m4a"
+        stream.urls = [stream.url]
         stream.codec = "aac"
         stream.container = "mp4"
         stream.manifestMimeType = "application/dash+xml"
+        stream.soundQuality = "HIGH"
         return stream
 
     def test_device_auth_pending_without_status_keeps_waiting(self):
@@ -250,6 +254,69 @@ class CliAuthPathRegressionTests(unittest.TestCase):
         finally:
             for key, value in old_values.items():
                 setattr(paths.SETTINGS, key, value)
+
+    def test_atmos_stream_adds_identifying_suffix_to_default_track_filename(self):
+        old_values = {
+            "downloadPath": paths.SETTINGS.downloadPath,
+            "trackFileFormat": paths.SETTINGS.trackFileFormat,
+            "audioQuality": paths.SETTINGS.audioQuality,
+        }
+        stream = self._stream()
+        stream.codec = "ec-3"
+        stream.soundQuality = "DOLBY_ATMOS"
+        try:
+            paths.SETTINGS.downloadPath = "/tmp/tidekeeper"
+            paths.SETTINGS.trackFileFormat = "{TrackNumber} - {ArtistName} - {TrackTitle}{ExplicitFlag}"
+            paths.SETTINGS.audioQuality = AudioQuality.Atmos
+
+            track_path = paths.getTrackPath(self._track(), stream, self._album())
+
+            self.assertTrue(track_path.endswith("01 - Artist - Track [Dolby Atmos].mp4"))
+        finally:
+            for key, value in old_values.items():
+                setattr(paths.SETTINGS, key, value)
+
+    def test_track_path_supports_stream_quality_and_codec_tokens(self):
+        old_values = {
+            "downloadPath": paths.SETTINGS.downloadPath,
+            "trackFileFormat": paths.SETTINGS.trackFileFormat,
+            "audioQuality": paths.SETTINGS.audioQuality,
+        }
+        stream = self._stream()
+        stream.codec = "ec-3"
+        stream.soundQuality = "DOLBY_ATMOS"
+        try:
+            paths.SETTINGS.downloadPath = "/tmp/tidekeeper"
+            paths.SETTINGS.trackFileFormat = "{TrackTitle} [{StreamQuality}] [{Codec}]"
+            paths.SETTINGS.audioQuality = AudioQuality.Atmos
+
+            track_path = paths.getTrackPath(self._track(), stream, self._album())
+
+            self.assertTrue(track_path.endswith("Track [Dolby Atmos] [ec-3].mp4"))
+        finally:
+            for key, value in old_values.items():
+                setattr(paths.SETTINGS, key, value)
+
+    def test_failed_track_log_is_reusable_as_link_file(self):
+        old_download_path = download.SETTINGS.downloadPath
+        track = self._track()
+        album = self._album()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                download.SETTINGS.downloadPath = temp_dir
+                with mock.patch.object(download.TIDAL_API, "getStreamUrl", side_effect=Exception("HTTP 429")):
+                    ok, msg = download.downloadTrack(track, album)
+
+                failed_log = Path(temp_dir) / "failed-tracks.txt"
+                self.assertFalse(ok)
+                self.assertIn("HTTP 429", msg)
+                self.assertTrue(failed_log.exists())
+                lines = failed_log.read_text(encoding="utf-8").splitlines()
+                retry_urls = [line for line in lines if line and not line.startswith("#")]
+                self.assertEqual(retry_urls, ["https://tidal.com/browse/track/456"])
+                self.assertTrue(any("Track" in line and "HTTP 429" in line for line in lines))
+            finally:
+                download.SETTINGS.downloadPath = old_download_path
 
 
 if __name__ == "__main__":

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -31,6 +31,8 @@ VIDEO_THREAD_COUNT = 8
 DOWNLOAD_RETRIES = 4
 DOWNLOAD_CHUNK_SIZE = 256 * 1024
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+FAILED_TRACKS_FILE = "failed-tracks.txt"
+failed_track_log_lock = Lock()
 
 
 def __removeFile__(path):
@@ -47,6 +49,52 @@ def __removeDir__(path):
             shutil.rmtree(path)
     except OSError as e:
         logging.warning("Unable to remove temporary directory %s: %s", path, e)
+
+
+def __failedTrackLogPath__():
+    return os.path.join(SETTINGS.downloadPath or ".", FAILED_TRACKS_FILE)
+
+
+def __tidalTrackUrl__(track):
+    return f"https://tidal.com/browse/track/{getattr(track, 'id', '')}"
+
+
+def __oneLine__(value):
+    return " ".join(str(value).split())
+
+
+def __logFailedTrack__(track, album=None, playlist=None, reason=""):
+    track_id = getattr(track, 'id', None)
+    if track_id is None:
+        return
+
+    try:
+        path = __failedTrackLogPath__()
+        __ensureParentDir__(path)
+        context = []
+        album_title = getattr(album, 'title', None)
+        playlist_title = getattr(playlist, 'title', None)
+        if album_title:
+            context.append(f"album={__oneLine__(album_title)}")
+        if playlist_title:
+            context.append(f"playlist={__oneLine__(playlist_title)}")
+
+        title = getattr(track, 'title', None) or str(track_id)
+        parts = [
+            time.strftime("%Y-%m-%d %H:%M:%S"),
+            f"track={__oneLine__(title)}",
+            f"id={track_id}",
+        ]
+        parts.extend(context)
+        if reason:
+            parts.append(f"reason={__oneLine__(reason)}")
+        entry = "# " + " | ".join(parts) + "\n" + __tidalTrackUrl__(track) + "\n"
+
+        with failed_track_log_lock:
+            with open(path, "a", encoding="utf-8") as output:
+                output.write(entry)
+    except Exception as e:
+        logging.warning("Unable to log failed track %s: %s", track_id, e)
 
 
 def __ensureParentDir__(path):
@@ -455,6 +503,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         )
         if not check:
             __removeFile__(partPath)
+            __logFailedTrack__(track, album, playlist, err)
             Printf.err(f"DL Track '{title}' failed: {str(err)}")
             return False, str(err)
 
@@ -479,6 +528,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         return True, ''
     except Exception as e:
         __removeFile__(locals().get('partPath', ''))
+        __logFailedTrack__(track, album, playlist, e)
         Printf.err(f"DL Track '{title}' failed: {str(e)}")
         return False, str(e)
 

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -52,6 +52,29 @@ def __getExtension__(stream: StreamUrl):
     return '.m4a'
 
 
+def __getStreamQuality__(stream: StreamUrl):
+    quality = (getattr(stream, 'soundQuality', None) or '').strip()
+    labels = {
+        'DOLBY_ATMOS': 'Dolby Atmos',
+        'HI_RES_LOSSLESS': 'Max',
+        'HI_RES': 'Master',
+        'LOSSLESS': 'HiFi',
+        'HIGH': 'High',
+        'LOW': 'Normal',
+    }
+    if quality in labels:
+        return labels[quality]
+    return quality.replace('_', ' ').title() if quality else ''
+
+
+def __isAtmosStream__(stream: StreamUrl):
+    return (getattr(stream, 'soundQuality', None) or '').upper() == 'DOLBY_ATMOS'
+
+
+def __hasStreamIdentifierToken__(pathFormat: str):
+    return '{StreamQuality}' in pathFormat or '{Codec}' in pathFormat
+
+
 def getAlbumPath(album):
     artistName = __fixPath__(TIDAL_API.getArtistsName(album.artists))
     albumArtistName = __fixPath__(album.artist.name) if album.artist is not None else ""
@@ -135,6 +158,7 @@ def getTrackPath(track, stream, album=None, playlist=None):
     retpath = SETTINGS.trackFileFormat
     if retpath is None or len(retpath) <= 0:
         retpath = SETTINGS.getDefaultPathFormat(Type.Track)
+    hasStreamIdentifier = __hasStreamIdentifierToken__(retpath)
     retpath = retpath.replace(R"{TrackNumber}", number)
     retpath = retpath.replace(R"{ArtistName}", artist)
     retpath = retpath.replace(R"{ArtistsName}", artists)
@@ -143,10 +167,14 @@ def getTrackPath(track, stream, album=None, playlist=None):
     retpath = retpath.replace(R"{AlbumYear}", year)
     retpath = retpath.replace(R"{AlbumTitle}", albumName)
     retpath = retpath.replace(R"{AudioQuality}", track.audioQuality)
+    retpath = retpath.replace(R"{StreamQuality}", __fixPath__(__getStreamQuality__(stream)))
+    retpath = retpath.replace(R"{Codec}", __fixPath__(stream.codec or ''))
     retpath = retpath.replace(R"{DurationSeconds}", str(track.duration))
     retpath = retpath.replace(R"{Duration}", __getDurationStr__(track.duration))
     retpath = retpath.replace(R"{TrackID}", str(track.id))
     retpath = retpath.strip()
+    if __isAtmosStream__(stream) and SETTINGS.audioQuality == AudioQuality.Atmos and not hasStreamIdentifier:
+        retpath += " [Dolby Atmos]"
     return f"{base}/{retpath}{extension}"
 
 


### PR DESCRIPTION
## Summary
- Log failed track downloads to `failed-tracks.txt` in the download folder.
- Store each failed track as a plain TIDAL track URL with comment metadata above it, so the file can be retried directly with `tidekeeper -l`.
- Add Atmos identification to track filenames. Default Atmos downloads get a `[Dolby Atmos]` suffix, and custom formats can use `{StreamQuality}` and `{Codec}`.
- Document Atmos usage and failed-track retry workflow in the README.

## Test Plan
- `python -m compileall -q tidal_dl`
- `python -m unittest discover -s tests`

Closes #3
Closes #4
