### PR TITLE
fix: fall back from blocked Atmos manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fall back to Max quality when an opt-in Atmos manifest request returns `CLIENT_NOT_ENTITLED`.
+
 ## 2026.5.17.4 - 2026-05-18
 
 - Added `SECURITY.md`, `CONTRIBUTING.md`, and release changelog docs.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ When an Atmos stream is downloaded, the default track filename gets a
 {TrackNumber} - {ArtistName} - {TrackTitle} [{StreamQuality}] [{Codec}]
 ```
 
+If TIDAL returns `CLIENT_NOT_ENTITLED` for the Atmos manifest, Tidekeeper falls
+back to Max quality for that track so the download can continue.
+
 If a track download fails, Tidekeeper appends it to `failed-tracks.txt` in the
 download folder. The file keeps comments with the title and reason, followed by
 a plain TIDAL track URL. Retry those tracks later with:

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import sys
 import tempfile
 import unittest
@@ -317,6 +319,35 @@ class CliAuthPathRegressionTests(unittest.TestCase):
                 self.assertTrue(any("Track" in line and "HTTP 429" in line for line in lines))
             finally:
                 download.SETTINGS.downloadPath = old_download_path
+
+    def test_atmos_client_not_entitled_falls_back_to_max_stream(self):
+        api = TidalAPI()
+        manifest = base64.b64encode(json.dumps({
+            "codecs": "flac",
+            "urls": ["https://example.invalid/fallback.flac"],
+            "mimeType": "audio/flac",
+        }).encode("utf-8")).decode("utf-8")
+
+        with mock.patch.object(
+            api,
+            "__getOpenApiTrackManifest__",
+            side_effect=Exception(
+                'Track manifest request failed: HTTP 403 {"errors":[{"code":"CLIENT_NOT_ENTITLED"}]}'
+            ),
+        ), mock.patch.object(api, "__get__", return_value={
+            "trackid": 456,
+            "audioQuality": "HI_RES_LOSSLESS",
+            "manifestMimeType": "application/vnd.tidal.bt",
+            "manifest": manifest,
+        }) as fallback_get:
+            stream = api.getStreamUrl(456, AudioQuality.Atmos)
+
+        self.assertEqual(stream.soundQuality, "HI_RES_LOSSLESS")
+        self.assertEqual(stream.url, "https://example.invalid/fallback.flac")
+        fallback_get.assert_called_once_with(
+            "tracks/456/playbackinfopostpaywall",
+            {"audioquality": "HI_RES_LOSSLESS", "playbackmode": "STREAM", "assetpresentation": "FULL"},
+        )
 
     def test_tidal_url_parser_ignores_query_strings_and_fragments(self):
         api = TidalAPI()

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -423,9 +423,18 @@ class TidalAPI(object):
             ret.url = ret.urls[0]
         return ret
 
+    def __isAtmosEntitlementError__(self, error):
+        message = str(error)
+        return "CLIENT_NOT_ENTITLED" in message or "HTTP 403" in message
+
     def getStreamUrl(self, id, quality: AudioQuality):
         if quality == AudioQuality.Atmos:
-            return self.__getAtmosStreamUrl__(id)
+            try:
+                return self.__getAtmosStreamUrl__(id)
+            except Exception as e:
+                if self.__isAtmosEntitlementError__(e):
+                    return self.getStreamUrl(id, AudioQuality.Max)
+                raise
 
         squality = "HI_RES"
         if quality == AudioQuality.Normal:


### PR DESCRIPTION
## Summary
- Fall back to Max quality when an opt-in Atmos manifest request returns CLIENT_NOT_ENTITLED or HTTP 403.
- Add regression coverage for the fallback path.
- Document the fallback behavior in the README and changelog.

## Test Plan
- pytest TIDALDL-PY/tests -q
- python -m compileall -q TIDALDL-PY/tidal_dl

Fixes #6