### PR TITLE
feat: add configurable audio quality priority

### DIFF
--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -11,6 +11,7 @@ import tidal_dl
 from tidal_dl import apiKey, download, events, paths
 from tidal_dl.enums import AudioQuality, Type, VideoQuality
 from tidal_dl.model import StreamUrl
+from tidal_dl.settings import Settings
 from tidal_dl.tidal import TidalAPI, TidalApiError
 
 
@@ -408,6 +409,136 @@ class CliAuthPathRegressionTests(unittest.TestCase):
                 ),
             ],
         )
+
+    def test_settings_read_parses_audio_quality_priority(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings_path = Path(temp_dir) / "settings.json"
+            settings_path.write_text(json.dumps({
+                "audioQuality": "Atmos",
+                "audioQualityPriority": ["Atmos", "High", "HiFi", "Normal"],
+                "videoQuality": "P360",
+            }), encoding="utf-8")
+
+            settings = Settings()
+            settings.read(str(settings_path))
+
+        self.assertEqual(settings.audioQuality, AudioQuality.Atmos)
+        self.assertEqual(settings.audioQualityPriority, [
+            AudioQuality.Atmos,
+            AudioQuality.High,
+            AudioQuality.HiFi,
+            AudioQuality.Normal,
+        ])
+
+    def test_settings_save_serializes_audio_quality_priority_names(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings_path = Path(temp_dir) / "settings.json"
+            settings = Settings()
+            settings.read(str(settings_path))
+            settings.audioQuality = AudioQuality.Atmos
+            settings.audioQualityPriority = [AudioQuality.Atmos, AudioQuality.High, AudioQuality.HiFi]
+            settings.save()
+
+            data = json.loads(settings_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["audioQuality"], "Atmos")
+        self.assertEqual(data["audioQualityPriority"], ["Atmos", "High", "HiFi"])
+
+    def test_audio_quality_priority_tries_high_before_lossless(self):
+        api = TidalAPI()
+        manifest = base64.b64encode(json.dumps({
+            "codecs": "aac",
+            "urls": ["https://example.invalid/fallback.m4a"],
+            "mimeType": "audio/mp4",
+        }).encode("utf-8")).decode("utf-8")
+
+        with mock.patch.object(
+            api,
+            "__getOpenApiTrackManifest__",
+            side_effect=Exception(
+                'Track manifest request failed: HTTP 403 {"errors":[{"code":"CLIENT_NOT_ENTITLED"}]}'
+            ),
+        ), mock.patch.object(api, "__get__", return_value={
+            "trackid": 456,
+            "audioQuality": "HIGH",
+            "manifestMimeType": "application/vnd.tidal.bt",
+            "manifest": manifest,
+        }) as fallback_get:
+            stream = api.getStreamUrlByPriority(456, [
+                "Atmos",
+                "High",
+                "HiFi",
+                "Normal",
+            ])
+
+        self.assertEqual(stream.soundQuality, "HIGH")
+        self.assertEqual(stream.url, "https://example.invalid/fallback.m4a")
+        fallback_get.assert_called_once_with(
+            "tracks/456/playbackinfopostpaywall",
+            {"audioquality": "HIGH", "playbackmode": "STREAM", "assetpresentation": "FULL"},
+        )
+
+    def test_download_track_uses_configured_audio_quality_priority(self):
+        old_priority = download.SETTINGS.audioQualityPriority
+        old_quality = download.SETTINGS.audioQuality
+        track = self._track()
+        try:
+            download.SETTINGS.audioQuality = AudioQuality.Atmos
+            download.SETTINGS.audioQualityPriority = [AudioQuality.Atmos, AudioQuality.High]
+            expected_stream = self._stream()
+            with mock.patch.object(
+                download.TIDAL_API,
+                "getStreamUrlByPriority",
+                return_value=expected_stream,
+            ) as priority_get:
+                stream = download.__getTrackStream__(track.id)
+
+            self.assertIs(stream, expected_stream)
+            priority_get.assert_called_once_with(track.id, [AudioQuality.Atmos, AudioQuality.High])
+        finally:
+            download.SETTINGS.audioQualityPriority = old_priority
+            download.SETTINGS.audioQuality = old_quality
+
+    def test_quality_priority_command_sets_fallback_order(self):
+        old_argv = sys.argv
+        old_quality = tidal_dl.SETTINGS.audioQuality
+        old_priority = tidal_dl.SETTINGS.audioQualityPriority
+        sys.argv = ["tidekeeper", "--quality-priority", "Atmos,High,HiFi,Normal"]
+        try:
+            with mock.patch.object(tidal_dl.aigpy.path, "mkdirs", return_value=True), \
+                 mock.patch.object(tidal_dl.SETTINGS, "save") as save:
+                tidal_dl.mainCommand()
+
+            self.assertEqual(tidal_dl.SETTINGS.audioQuality, AudioQuality.Atmos)
+            self.assertEqual(tidal_dl.SETTINGS.audioQualityPriority, [
+                AudioQuality.Atmos,
+                AudioQuality.High,
+                AudioQuality.HiFi,
+                AudioQuality.Normal,
+            ])
+            save.assert_called()
+        finally:
+            sys.argv = old_argv
+            tidal_dl.SETTINGS.audioQuality = old_quality
+            tidal_dl.SETTINGS.audioQualityPriority = old_priority
+
+    def test_quality_command_clears_fallback_order(self):
+        old_argv = sys.argv
+        old_quality = tidal_dl.SETTINGS.audioQuality
+        old_priority = tidal_dl.SETTINGS.audioQualityPriority
+        sys.argv = ["tidekeeper", "--quality", "High"]
+        try:
+            tidal_dl.SETTINGS.audioQualityPriority = [AudioQuality.Atmos, AudioQuality.High]
+            with mock.patch.object(tidal_dl.aigpy.path, "mkdirs", return_value=True), \
+                 mock.patch.object(tidal_dl.SETTINGS, "save"):
+                tidal_dl.mainCommand()
+
+            self.assertEqual(tidal_dl.SETTINGS.audioQuality, AudioQuality.High)
+            self.assertEqual(tidal_dl.SETTINGS.audioQualityPriority, [])
+        finally:
+            sys.argv = old_argv
+            tidal_dl.SETTINGS.audioQuality = old_quality
+            tidal_dl.SETTINGS.audioQualityPriority = old_priority
 
     def test_tidal_url_parser_ignores_query_strings_and_fragments(self):
         api = TidalAPI()

--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -25,7 +25,7 @@ def mainCommand():
                                    "hvgl:o:q:r:",
                                    [
                                        "help", "version", "gui", "doctor",
-                                       "link=", "output=", "quality=", "resolution="
+                                       "link=", "output=", "quality=", "quality-priority=", "resolution="
                                    ])
     except getopt.GetoptError as errmsg:
         Printf.err(vars(errmsg)['msg'] + ". Use 'tidal-dl -h' for usage.")
@@ -57,6 +57,13 @@ def mainCommand():
             continue
         if opt in ('-q', '--quality'):
             SETTINGS.audioQuality = SETTINGS.getAudioQuality(val)
+            SETTINGS.audioQualityPriority = []
+            SETTINGS.save()
+            continue
+        if opt in ('--quality-priority',):
+            SETTINGS.audioQualityPriority = SETTINGS.getAudioQualityPriority(val)
+            if SETTINGS.audioQualityPriority:
+                SETTINGS.audioQuality = SETTINGS.audioQualityPriority[0]
             SETTINGS.save()
             continue
         if opt in ('-r', '--resolution'):

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -467,10 +467,17 @@ def downloadVideo(video: Video, album: Album = None, playlist: Playlist = None):
         return False, str(e)
 
 
+def __getTrackStream__(track_id):
+    priority = SETTINGS.getDownloadAudioQualityPriority()
+    if len(priority) > 1:
+        return TIDAL_API.getStreamUrlByPriority(track_id, priority)
+    return TIDAL_API.getStreamUrl(track_id, priority[0])
+
+
 def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, partSize=DEFAULT_PART_SIZE):
     title = getattr(track, 'title', None) or str(getattr(track, 'id', 'unknown'))
     try:
-        stream = TIDAL_API.getStreamUrl(track.id, SETTINGS.audioQuality)
+        stream = __getTrackStream__(track.id)
         path = getTrackPath(track, stream, album, playlist)
         partPath = path + '.part'
 

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -157,6 +157,10 @@ def changeQualitySettings():
         int(Printf.enterLimit(LANG.select.CHANGE_AUDIO_QUALITY,
                               LANG.select.MSG_INPUT_ERR,
                               ['0', '1', '2', '3', '4', '5'])))
+    priority = Printf.enter(
+        "Audio quality priority comma list, blank for single quality, e.g. Atmos,High,HiFi,Normal:"
+    )
+    SETTINGS.audioQualityPriority = SETTINGS.getAudioQualityPriority(priority)
     SETTINGS.videoQuality = VideoQuality(
         int(Printf.enterLimit(LANG.select.CHANGE_VIDEO_QUALITY,
                               LANG.select.MSG_INPUT_ERR,

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -87,6 +87,7 @@ class Printf(object):
                 ("-l, --link URL", "Download URL/ID/file"),
                 ("-o, --output PATH", "Set save folder"),
                 ("-q, --quality NAME", "Normal, High, HiFi, Master, Max, Atmos"),
+                ("--quality-priority LIST", "Fallback order, e.g. Atmos,High,HiFi,Normal"),
                 ("-r, --resolution NAME", "P1080, P720, P480, P360"),
             ]
             for option, description in rows:
@@ -101,7 +102,8 @@ class Printf(object):
             ["--doctor", "Check config, auth, and local tools"],
             ["-l, --link", "Download a Tidal URL, ID, or text file"],
             ["-o, --output", "Set download path"],
-            ["-q, --quality", "Set audio quality: Normal, High, HiFi, Master, Max, Atmos"],
+            ["-q, --quality", "Set one audio quality: Normal, High, HiFi, Master, Max, Atmos"],
+            ["--quality-priority", "Set fallback order, e.g. Atmos,High,HiFi,Normal"],
             ["-r, --resolution", "Set video quality: P1080, P720, P480, P360"]
         ])
         tb.set_style(prettytable.PLAIN_COLUMNS)
@@ -129,6 +131,7 @@ class Printf(object):
 
             #settings - quality
             [LANG.select.SETTING_AUDIO_QUALITY, data.audioQuality],
+            ["Audio quality priority", ",".join(item.name for item in data.getAudioQualityPriority(data.audioQualityPriority)) or "off"],
             [LANG.select.SETTING_VIDEO_QUALITY, data.videoQuality],
 
             #settings - else
@@ -157,6 +160,9 @@ class Printf(object):
         compact = Printf.__isCompact__()
         path = Printf.__shorten__(data.downloadPath, 42 if compact else 68)
         audio = Printf.__enumName__(data.audioQuality)
+        priority = data.getAudioQualityPriority(data.audioQualityPriority)
+        if priority:
+            audio = ">".join(item.name for item in priority)
         video = Printf.__enumName__(data.videoQuality)
 
         print("")

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -34,6 +34,7 @@ class Settings(aigpy.model.ModelBase):
 
     downloadPath = "./download/"
     audioQuality = AudioQuality.Normal
+    audioQualityPriority = []
     videoQuality = VideoQuality.P360
     usePlaylistFolder = True
     albumFolderFormat = R"{ArtistName}/{Flag} {AlbumTitle} [{AlbumID}] [{AlbumYear}]"
@@ -52,13 +53,41 @@ class Settings(aigpy.model.ModelBase):
             return R"{VideoNumber} - {ArtistName} - {VideoTitle}{ExplicitFlag}"
         return ""
 
-    def getAudioQuality(self, value):
+    def getAudioQualityOrNone(self, value):
         for item in AudioQuality:
+            if item == value:
+                return item
             if item.name == value:
                 return item
             if str(value).lower() == item.name.lower():
                 return item
-        return AudioQuality.Normal
+        return None
+
+    def getAudioQuality(self, value):
+        return self.getAudioQualityOrNone(value) or AudioQuality.Normal
+
+    def getAudioQualityPriority(self, value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [item.strip() for item in value.split(',')]
+        elif isinstance(value, AudioQuality):
+            value = [value]
+
+        priority = []
+        for item in value:
+            if item is None or str(item).strip() == "":
+                continue
+            quality = self.getAudioQualityOrNone(item)
+            if quality is not None and quality not in priority:
+                priority.append(quality)
+        return priority
+
+    def getDownloadAudioQualityPriority(self):
+        priority = self.getAudioQualityPriority(self.audioQualityPriority)
+        if priority:
+            return priority
+        return [self.audioQuality]
 
     def getVideoQuality(self, value):
         for item in VideoQuality:
@@ -76,6 +105,7 @@ class Settings(aigpy.model.ModelBase):
                 return
 
         self.audioQuality = self.getAudioQuality(self.audioQuality)
+        self.audioQualityPriority = self.getAudioQualityPriority(self.audioQualityPriority)
         self.videoQuality = self.getVideoQuality(self.videoQuality)
 
         if self.albumFolderFormat is None:
@@ -96,6 +126,7 @@ class Settings(aigpy.model.ModelBase):
     def save(self):
         data = aigpy.model.modelToDict(self)
         data['audioQuality'] = self.audioQuality.name
+        data['audioQualityPriority'] = [item.name for item in self.getAudioQualityPriority(self.audioQualityPriority)]
         data['videoQuality'] = self.videoQuality.name
         txt = json.dumps(data)
         aigpy.file.write(self._path_, txt, 'w+')

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -532,6 +532,14 @@ class TidalAPI(object):
         message = str(error)
         return "CLIENT_NOT_ENTITLED" in message or "HTTP 403" in message
 
+    def __normalizeAudioQuality__(self, quality):
+        if isinstance(quality, AudioQuality):
+            return quality
+        for item in AudioQuality:
+            if item.name == quality or str(quality).lower() == item.name.lower():
+                return item
+        return None
+
     def __getStandardStreamUrl__(self, id, quality: AudioQuality):
         paras = {
             "audioquality": self.__audioQualityParam__(quality),
@@ -568,6 +576,30 @@ class TidalAPI(object):
             return ret
 
         raise Exception("Can't get the streamUrl, type is " + resp.manifestMimeType)
+
+    def getStreamUrlByPriority(self, id, qualities):
+        priority = []
+        for quality in qualities or []:
+            normalized = self.__normalizeAudioQuality__(quality)
+            if normalized is not None and normalized not in priority:
+                priority.append(normalized)
+        if not priority:
+            priority = [AudioQuality.Normal]
+
+        lastError = None
+        requestedQuality = priority[0]
+        for index, item in enumerate(priority):
+            try:
+                if item == AudioQuality.Atmos:
+                    stream = self.__getAtmosStreamUrl__(id)
+                else:
+                    stream = self.__getStandardStreamUrl__(id, item)
+                return self.__annotateStreamFallback__(stream, requestedQuality, item, lastError)
+            except Exception as e:
+                lastError = e
+                if index == len(priority) - 1 or not self.__isStreamFallbackError__(e):
+                    raise
+        raise lastError
 
     def getStreamUrl(self, id, quality: AudioQuality):
         lastError = None


### PR DESCRIPTION
## Summary
- Add audioQualityPriority setting for user-defined audio fallback order.
- Add --quality-priority CLI option, for example Atmos,High,HiFi,Normal.
- Use the configured priority during track downloads while preserving single --quality behaviour.
- Keep stream fallback annotations and add regression coverage for the new path.

## Test Plan
- pytest TIDALDL-PY/tests -q
- python -m compileall -q TIDALDL-PY/tidal_dl

## Notes
This lets users prefer Atmos first, then AAC 320, then lossless, then AAC 96 instead of always taking the default fallback order.