### PR TITLE
Fix open issues: GUI contrast, FLAC export, request interval, playback retries

### DIFF
--- a/TIDALDL-PY/tests/test_download_backend.py
+++ b/TIDALDL-PY/tests/test_download_backend.py
@@ -4,6 +4,7 @@ import threading
 import unittest
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from tidal_dl import download
@@ -109,6 +110,68 @@ class DownloadBackendTests(unittest.TestCase):
         self.assertEqual(output_file.read_bytes(), b"first-second")
         self.assertFalse(partial_file.exists())
         self.assertEqual(request.call_args.kwargs["headers"], {"Range": "bytes=6-"})
+
+    def test_flac_export_without_ffmpeg_falls_back_to_m4a_container(self):
+        old_value = download.SETTINGS.saveAsFlac
+        source = self.root / "track.flac"
+        source.write_bytes(b"mp4-container")
+        stream = SimpleNamespace(codec="flac", container="mp4", manifestMimeType="application/dash+xml")
+        try:
+            download.SETTINGS.saveAsFlac = True
+            with mock.patch.object(download.shutil, "which", return_value=None):
+                final_path = download.__exportFlacFromContainer__(str(source), stream)
+        finally:
+            download.SETTINGS.saveAsFlac = old_value
+
+        fallback = self.root / "track.m4a"
+        self.assertEqual(final_path, str(fallback))
+        self.assertFalse(source.exists())
+        self.assertEqual(fallback.read_bytes(), b"mp4-container")
+
+    def test_flac_export_uses_ffmpeg_flac_muxer(self):
+        old_value = download.SETTINGS.saveAsFlac
+        source = self.root / "track.flac"
+        source.write_bytes(b"mp4-container")
+        stream = SimpleNamespace(codec="flac", container="mp4", manifestMimeType="application/dash+xml")
+
+        def fake_run(command, **kwargs):
+            Path(command[-1]).write_bytes(b"raw-flac")
+            return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+        try:
+            download.SETTINGS.saveAsFlac = True
+            with mock.patch.object(download.shutil, "which", return_value="/usr/bin/ffmpeg"), \
+                 mock.patch.object(download.subprocess, "run", side_effect=fake_run) as run:
+                final_path = download.__exportFlacFromContainer__(str(source), stream)
+        finally:
+            download.SETTINGS.saveAsFlac = old_value
+
+        self.assertEqual(final_path, str(source))
+        self.assertEqual(source.read_bytes(), b"raw-flac")
+        self.assertIn("-f", run.call_args.args[0])
+        self.assertIn("flac", run.call_args.args[0])
+
+    def test_save_as_flac_skip_accepts_existing_remuxed_file(self):
+        old_values = {
+            "saveAsFlac": download.SETTINGS.saveAsFlac,
+            "checkExist": download.SETTINGS.checkExist,
+        }
+        existing = self.root / "track.flac"
+        existing.write_bytes(b"raw-flac")
+        stream = SimpleNamespace(
+            urls=["https://example.invalid/init.mp4"],
+            codec="flac",
+            container="mp4",
+            manifestMimeType="application/dash+xml",
+        )
+        try:
+            download.SETTINGS.saveAsFlac = True
+            download.SETTINGS.checkExist = True
+            with mock.patch.object(download, "__remoteSize__", return_value=-1):
+                self.assertEqual(download.__skipPath__(str(existing), stream), str(existing))
+        finally:
+            for key, value in old_values.items():
+                setattr(download.SETTINGS, key, value)
 
 
 if __name__ == "__main__":

--- a/TIDALDL-PY/tests/test_paths.py
+++ b/TIDALDL-PY/tests/test_paths.py
@@ -13,7 +13,20 @@ class PathTests(unittest.TestCase):
         stream.manifestMimeType = "application/dash+xml"
         stream.container = "mp4"
 
-        self.assertEqual(__getExtension__(stream), ".m4a")
+        with mock.patch("tidal_dl.paths.SETTINGS") as settings:
+            settings.saveAsFlac = False
+            self.assertEqual(__getExtension__(stream), ".m4a")
+
+    def test_save_as_flac_setting_uses_flac_extension_for_dash_flac(self):
+        stream = StreamUrl()
+        stream.url = "https://example.invalid/init.mp4"
+        stream.codec = "flac"
+        stream.manifestMimeType = "application/dash+xml"
+        stream.container = "mp4"
+
+        with mock.patch("tidal_dl.paths.SETTINGS") as settings:
+            settings.saveAsFlac = True
+            self.assertEqual(__getExtension__(stream), ".flac")
 
     def test_native_flac_url_uses_flac_extension(self):
         stream = StreamUrl()

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -355,6 +355,41 @@ class CliAuthPathRegressionTests(unittest.TestCase):
             for key, value in old_values.items():
                 setattr(events.TOKEN, key, value)
 
+    def test_playback_asset_not_ready_retries_before_failing(self):
+        api = TidalAPI()
+        manifest = base64.b64encode(json.dumps({
+            "codecs": "flac",
+            "urls": ["https://example.invalid/track.flac"],
+            "mimeType": "audio/flac",
+        }).encode("utf-8")).decode("utf-8")
+
+        def fake_response(status_code, payload):
+            return SimpleNamespace(
+                status_code=status_code,
+                text=json.dumps(payload),
+                headers={},
+                close=mock.Mock(),
+            )
+
+        with mock.patch.object(api, "__refreshSavedAccessToken__", return_value=False), \
+             mock.patch("tidal_dl.tidal.time.sleep") as sleep, \
+             mock.patch.object(api.session, "get", side_effect=[
+                 fake_response(401, {"status": 401, "subStatus": 4005, "userMessage": "Asset is not ready for playback"}),
+                 fake_response(200, {
+                     "trackid": 123,
+                     "audioQuality": "LOSSLESS",
+                     "manifestMimeType": "application/vnd.tidal.bt",
+                     "manifest": manifest,
+                 }),
+             ]):
+            data = api.__get__(
+                "tracks/123/playbackinfopostpaywall",
+                {"audioquality": "LOSSLESS", "playbackmode": "STREAM", "assetpresentation": "FULL"},
+            )
+
+        self.assertEqual(data["trackid"], 123)
+        sleep.assert_called_once()
+
     def test_playback_api_requests_use_rate_limiter(self):
         api = TidalAPI()
         old_delay = events.SETTINGS.downloadDelay

--- a/TIDALDL-PY/tidal_dl/diagnostics.py
+++ b/TIDALDL-PY/tidal_dl/diagnostics.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 import os
 import shutil
+import sys
 
 import aigpy
 
@@ -69,6 +70,8 @@ def __checkToken__():
 
 def runDoctor():
     print("Tidekeeper doctor")
+    if sys.platform.startswith("win"):
+        Printf.info("Platform: Windows - check folder permissions, long paths, antivirus blocking, and protected directories if downloads fail.")
     checks = [
         __checkDownloadPath__(),
         __checkApiKey__(),

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -365,6 +365,21 @@ def __isSkip__(finalpath, urls):
     return curSize >= netSize
 
 
+def __downloadErrorHint__(err):
+    text = str(err or "").lower()
+    if any(item in text for item in ("429", "too many requests", "rate limit")):
+        return " (hint: raise the request interval in settings and retry)"
+    if any(item in text for item in ("403", "entitled", "not allowed", "client_not_entitled")):
+        return " (hint: stream may be unavailable for this account or quality; try a lower quality/fallback order)"
+    if any(item in text for item in ("timeout", "connection", "network", "name or service not known")):
+        return " (hint: check network/VPN/proxy/firewall, or run tidekeeper --doctor)"
+    if any(item in text for item in ("permission", "denied", "access is denied", "readonly")):
+        return " (hint: choose a writable download folder outside protected system directories)"
+    if "disk" in text or "space" in text or "no space" in text:
+        return " (hint: check available disk space)"
+    return ""
+
+
 def __encrypted__(stream, srcPath, descPath):
     if aigpy.string.isNull(stream.encryptionKey):
         os.replace(srcPath, descPath)
@@ -832,7 +847,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         if not check:
             __removeFile__(partPath)
             __logFailedTrack__(track, album, playlist, err)
-            Printf.err(f"DL Track '{title}' failed: {str(err)}")
+            Printf.err(f"DL Track '{title}' failed: {str(err)}{__downloadErrorHint__(err)}")
             return False, str(err)
 
         # encrypted -> decrypt and remove encrypted file
@@ -858,7 +873,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
     except Exception as e:
         __removeFile__(locals().get('partPath', ''))
         __logFailedTrack__(track, album, playlist, e)
-        Printf.err(f"DL Track '{title}' failed: {str(e)}")
+        Printf.err(f"DL Track '{title}' failed: {str(e)}{__downloadErrorHint__(e)}")
         return False, str(e)
 
 

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -381,21 +381,42 @@ def __isFlacInM4a__(stream):
     return 'flac' in codec and ('mp4' in container or 'dash+xml' in manifestMimeType)
 
 
+def __containerFallbackPath__(path):
+    return path.rsplit('.', 1)[0] + '.m4a'
+
+
+def __skipPath__(path, stream):
+    if __isSkip__(path, stream.urls):
+        return path
+
+    if not SETTINGS.checkExist:
+        return None
+
+    if SETTINGS.saveAsFlac and __isFlacInM4a__(stream):
+        for candidate in (path, __containerFallbackPath__(path)):
+            if aigpy.file.getSize(candidate) > 0:
+                return candidate
+    return None
+
+
 def __exportFlacFromContainer__(path, stream):
     if not SETTINGS.saveAsFlac or not __isFlacInM4a__(stream):
         return path
 
     flacPath = path.rsplit('.', 1)[0] + '.flac'
+    fallbackPath = __containerFallbackPath__(path)
     ffmpeg = shutil.which('ffmpeg')
     if not ffmpeg:
-        logging.warning("saveAsFlac is enabled but ffmpeg was not found; keeping %s", path)
-        return path
+        logging.warning("saveAsFlac is enabled but ffmpeg was not found; saving container as %s", fallbackPath)
+        if os.path.abspath(path) != os.path.abspath(fallbackPath):
+            os.replace(path, fallbackPath)
+        return fallbackPath
 
-    tempPath = flacPath + f'.tmp.{os.getpid()}'
+    tempPath = f"{flacPath}.tmp.{os.getpid()}.flac"
     __removeFile__(tempPath)
     try:
         completed = subprocess.run(
-            [ffmpeg, '-y', '-hide_banner', '-loglevel', 'error', '-i', path, '-map', '0:a:0', '-c', 'copy', tempPath],
+            [ffmpeg, '-y', '-hide_banner', '-loglevel', 'error', '-i', path, '-map', '0:a:0', '-c', 'copy', '-f', 'flac', tempPath],
             capture_output=True,
             text=True,
             check=False,
@@ -409,8 +430,10 @@ def __exportFlacFromContainer__(path, stream):
         return flacPath
     except Exception as e:
         __removeFile__(tempPath)
-        logging.warning("Unable to export FLAC for %s: %s", path, e)
-        return path
+        logging.warning("Unable to export FLAC for %s: %s; saving container as %s", path, e, fallbackPath)
+        if os.path.abspath(path) != os.path.abspath(fallbackPath):
+            os.replace(path, fallbackPath)
+        return fallbackPath
 
 
 def __lyricsText__(value):
@@ -785,10 +808,11 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
             userProgress.updateStream(stream)
 
         # check exist
-        if __isSkip__(path, stream.urls):
+        skipPath = __skipPath__(path, stream)
+        if skipPath is not None:
             if SETTINGS.lyricFile:
-                __saveLyricsForTrack__(track, path)
-            Printf.success(aigpy.path.getFileName(path) + " (skip:already exists!)")
+                __saveLyricsForTrack__(track, skipPath)
+            Printf.success(aigpy.path.getFileName(skipPath) + " (skip:already exists!)")
             return True, ''
 
         # download

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import shutil
+import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock, local
@@ -371,6 +372,45 @@ def __encrypted__(stream, srcPath, descPath):
         key, nonce = decrypt_security_token(stream.encryptionKey)
         decrypt_file(srcPath, descPath, key, nonce)
         os.remove(srcPath)
+
+
+def __isFlacInM4a__(stream):
+    codec = (getattr(stream, 'codec', None) or '').lower()
+    container = (getattr(stream, 'container', None) or '').lower()
+    manifestMimeType = (getattr(stream, 'manifestMimeType', None) or '').lower()
+    return 'flac' in codec and ('mp4' in container or 'dash+xml' in manifestMimeType)
+
+
+def __exportFlacFromContainer__(path, stream):
+    if not SETTINGS.saveAsFlac or not __isFlacInM4a__(stream):
+        return path
+
+    flacPath = path.rsplit('.', 1)[0] + '.flac'
+    ffmpeg = shutil.which('ffmpeg')
+    if not ffmpeg:
+        logging.warning("saveAsFlac is enabled but ffmpeg was not found; keeping %s", path)
+        return path
+
+    tempPath = flacPath + f'.tmp.{os.getpid()}'
+    __removeFile__(tempPath)
+    try:
+        completed = subprocess.run(
+            [ffmpeg, '-y', '-hide_banner', '-loglevel', 'error', '-i', path, '-map', '0:a:0', '-c', 'copy', tempPath],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or '').strip()
+            raise RuntimeError(detail or f"ffmpeg exited with code {completed.returncode}")
+        os.replace(tempPath, flacPath)
+        if os.path.abspath(path) != os.path.abspath(flacPath):
+            __removeFile__(path)
+        return flacPath
+    except Exception as e:
+        __removeFile__(tempPath)
+        logging.warning("Unable to export FLAC for %s: %s", path, e)
+        return path
 
 
 def __lyricsText__(value):
@@ -773,6 +813,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
 
         # encrypted -> decrypt and remove encrypted file
         __encrypted__(stream, partPath, path)
+        path = __exportFlacFromContainer__(path, stream)
 
         # contributors
         try:

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -198,8 +198,24 @@ def changeSettings():
     SETTINGS.multiThread = Printf.enterBool(LANG.select.CHANGE_MULITHREAD_DOWNLOAD)
     SETTINGS.usePlaylistFolder = Printf.enterBool(LANG.select.SETTING_USE_PLAYLIST_FOLDER + "('0'-No,'1'-Yes):")
     SETTINGS.downloadDelay = Printf.enterBool(LANG.select.CHANGE_USE_DOWNLOAD_DELAY)
+    interval_prompt = getattr(
+        LANG.select,
+        "CHANGE_REQUEST_INTERVAL_SECONDS",
+        "Request delay seconds (0=off, 30 or 60 can help rate limits):",
+    )
+    interval = Printf.enter(interval_prompt)
+    try:
+        SETTINGS.requestIntervalSeconds = max(0.0, float(interval))
+    except (TypeError, ValueError):
+        Printf.info("Keeping existing request delay seconds.")
+    SETTINGS.saveAsFlac = Printf.enterBool(getattr(
+        LANG.select,
+        "CHANGE_SAVE_AS_FLAC",
+        "Save FLAC streams as .flac files when ffmpeg can remux them('0'-No,'1'-Yes):",
+    ))
     SETTINGS.language = Printf.enter(LANG.select.CHANGE_LANGUAGE + "(" + LANG.getLangChoicePrint() + "):")
     LANG.setLang(SETTINGS.language)
+    syncPlaybackRateLimiter()
     SETTINGS.save()
 
 

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -408,6 +408,8 @@ class DemoBackend(TidekeeperBackend):
         SETTINGS.downloadVideos = False
         SETTINGS.multiThread = False
         SETTINGS.downloadDelay = True
+        SETTINGS.requestIntervalSeconds = 1.0
+        SETTINGS.saveAsFlac = False
         SETTINGS.usePlaylistFolder = True
 
     def auth_status(self) -> AuthStatus:

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -17,7 +17,7 @@ from ..events import loginByConfig, logout, start, start_type
 from ..lang.language import LANG
 from ..paths import getProfilePath, getTokenPath, openPath
 from ..printf import VERSION
-from ..settings import SETTINGS, TOKEN
+from ..settings import SETTINGS, TOKEN, syncPlaybackRateLimiter
 from ..tidal import TIDAL_API
 from ..updater import run_update
 
@@ -318,6 +318,8 @@ class TidekeeperBackend:
         SETTINGS.downloadVideos = values["downloadVideos"]
         SETTINGS.multiThread = values["multiThread"]
         SETTINGS.downloadDelay = values["downloadDelay"]
+        SETTINGS.requestIntervalSeconds = max(0.0, float(values.get("requestIntervalSeconds", 1.0) or 0.0))
+        SETTINGS.saveAsFlac = values.get("saveAsFlac", False)
         SETTINGS.usePlaylistFolder = values["usePlaylistFolder"]
         SETTINGS.showProgress = values["showProgress"]
         SETTINGS.showTrackInfo = values["showTrackInfo"]
@@ -330,6 +332,7 @@ class TidekeeperBackend:
         TIDAL_API.apiKey = apiKey.getItem(SETTINGS.apiKeyIndex)
         LANG.setLang(SETTINGS.language)
         SETTINGS.save()
+        syncPlaybackRateLimiter()
 
     def open_download_folder(self, path: str = "") -> str:
         return openPath(path or SETTINGS.downloadPath)

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -4,11 +4,12 @@ import webbrowser
 from typing import Dict, List, Tuple
 
 from PySide6.QtCore import Qt, QThreadPool, QTimer
-from PySide6.QtGui import QColor, QTextCursor
+from PySide6.QtGui import QColor, QPalette, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFileDialog,
     QFrame,
     QGridLayout,
@@ -21,7 +22,6 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
-    QSpinBox,
     QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
@@ -362,8 +362,10 @@ class MainWindow(QMainWindow):
         ):
             self.checks[key] = QCheckBox(label)
 
-        self.request_interval = QSpinBox()
-        self.request_interval.setRange(0, 300)
+        self.request_interval = QDoubleSpinBox()
+        self.request_interval.setRange(0.0, 300.0)
+        self.request_interval.setSingleStep(0.5)
+        self.request_interval.setDecimals(1)
         self.request_interval.setSuffix(" s")
         self.request_interval.setToolTip("Minimum delay between TIDAL playback API requests.")
         self.checks["downloadDelay"].toggled.connect(self._update_request_interval_enabled)
@@ -890,7 +892,7 @@ class MainWindow(QMainWindow):
         self.api_client.setCurrentIndex(client_index if client_index >= 0 else 0)
         for key, checkbox in self.checks.items():
             checkbox.setChecked(bool(getattr(SETTINGS, key)))
-        self.request_interval.setValue(int(max(0, round(float(getattr(SETTINGS, 'requestIntervalSeconds', 1.0) or 0)))))
+        self.request_interval.setValue(max(0.0, float(getattr(SETTINGS, 'requestIntervalSeconds', 1.0) or 0.0)))
         self._update_request_interval_enabled(self.checks["downloadDelay"].isChecked())
         self.album_format.setText(SETTINGS.albumFolderFormat)
         self.playlist_format.setText(SETTINGS.playlistFolderFormat)
@@ -1091,6 +1093,21 @@ class MainWindow(QMainWindow):
 
 def configure_application_theme(app: QApplication):
     app.setStyle("Fusion")
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor("#f5f7fb"))
+    palette.setColor(QPalette.WindowText, QColor("#172033"))
+    palette.setColor(QPalette.Base, QColor("#ffffff"))
+    palette.setColor(QPalette.AlternateBase, QColor("#f8fafc"))
+    palette.setColor(QPalette.Text, QColor("#172033"))
+    palette.setColor(QPalette.Button, QColor("#ffffff"))
+    palette.setColor(QPalette.ButtonText, QColor("#172033"))
+    palette.setColor(QPalette.Highlight, QColor("#0f766e"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.ToolTipBase, QColor("#ffffff"))
+    palette.setColor(QPalette.ToolTipText, QColor("#172033"))
+    palette.setColor(QPalette.Disabled, QPalette.Text, QColor("#98a2b3"))
+    palette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor("#98a2b3"))
+    app.setPalette(palette)
     hints = app.styleHints()
     if hasattr(hints, "setColorScheme"):
         hints.setColorScheme(Qt.ColorScheme.Light)

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -4,7 +4,7 @@ import webbrowser
 from typing import Dict, List, Tuple
 
 from PySide6.QtCore import Qt, QThreadPool, QTimer
-from PySide6.QtGui import QTextCursor
+from PySide6.QtGui import QColor, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
+    QSpinBox,
     QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
@@ -32,7 +33,7 @@ from PySide6.QtWidgets import (
 from ..enums import AudioQuality, Type, VideoQuality
 from ..settings import SETTINGS
 from .backend import SearchItem, TidekeeperBackend, with_video_only
-from .style import APP_STYLESHEET
+from .style import APP_STYLESHEET, TABLE_TEXT_COLOR
 from .workers import DownloadWorker, TaskWorker
 
 
@@ -356,9 +357,16 @@ class MainWindow(QMainWindow):
             ("downloadVideos", "Download videos"),
             ("multiThread", "Parallel downloads"),
             ("downloadDelay", "Use request delay"),
+            ("saveAsFlac", "Save FLAC as .flac files"),
             ("usePlaylistFolder", "Use playlist folders"),
         ):
             self.checks[key] = QCheckBox(label)
+
+        self.request_interval = QSpinBox()
+        self.request_interval.setRange(0, 300)
+        self.request_interval.setSuffix(" s")
+        self.request_interval.setToolTip("Minimum delay between TIDAL playback API requests.")
+        self.checks["downloadDelay"].toggled.connect(self._update_request_interval_enabled)
 
         self.album_format = QLineEdit()
         self.playlist_format = QLineEdit()
@@ -438,13 +446,16 @@ class MainWindow(QMainWindow):
         groups = [
             ("Files", ["checkExist", "saveCovers", "lyricFile", "saveAlbumInfo", "usePlaylistFolder"]),
             ("Catalog", ["includeEP", "downloadVideos"]),
-            ("Run behavior", ["multiThread", "downloadDelay", "showProgress", "showTrackInfo"]),
+            ("Run behavior", ["multiThread", "downloadDelay", "saveAsFlac", "showProgress", "showTrackInfo"]),
         ]
         for column, (title, keys) in enumerate(groups):
             grid.addWidget(_label(title, "SectionTitle"), 0, column)
             for row, key in enumerate(keys, start=1):
                 grid.addWidget(self.checks[key], row, column)
             grid.setColumnStretch(column, 1)
+        grid.addWidget(_label("Request interval", "SectionTitle"), 0, len(groups))
+        grid.addWidget(self.request_interval, 1, len(groups))
+        grid.setColumnStretch(len(groups), 1)
         return _panel(grid)
 
     def _build_naming_settings_panel(self) -> QFrame:
@@ -549,6 +560,16 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.account_log, 1)
         return page
 
+    def _table_cell(self, value, item=None) -> QTableWidgetItem:
+        cell = QTableWidgetItem(str(value))
+        cell.setForeground(QColor(TABLE_TEXT_COLOR))
+        if item is not None:
+            cell.setData(Qt.UserRole, item)
+        return cell
+
+    def _update_request_interval_enabled(self, enabled: bool):
+        self.request_interval.setEnabled(enabled)
+
     def _setup_table(self, table: QTableWidget, headers: List[str]):
         table.setHorizontalHeaderLabels(headers)
         table.verticalHeader().setVisible(False)
@@ -610,9 +631,7 @@ class MainWindow(QMainWindow):
         for row, item in enumerate(items):
             values = [item.kind.name, item.title, item.artists, item.quality, item.duration, item.identifier]
             for col, value in enumerate(values):
-                cell = QTableWidgetItem(str(value))
-                if col == 0:
-                    cell.setData(Qt.UserRole, item)
+                cell = self._table_cell(value, item if col == 0 else None)
                 if col == 5:
                     cell.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
                 self.results_table.setItem(row, col, cell)
@@ -764,10 +783,7 @@ class MainWindow(QMainWindow):
                 kind += " videos"
             values = [kind, item.title, item.artists, item.quality, "Queued"]
             for col, value in enumerate(values):
-                cell = QTableWidgetItem(str(value))
-                if col == 0:
-                    cell.setData(Qt.UserRole, item)
-                self.queue_table.setItem(row, col, cell)
+                self.queue_table.setItem(row, col, self._table_cell(value, item if col == 0 else None))
         self.queue_table.setSortingEnabled(True)
         self.queue_status.setText(f"{len(self.queue)} item{'s' if len(self.queue) != 1 else ''} in queue.")
         self.update_queue_actions()
@@ -874,6 +890,8 @@ class MainWindow(QMainWindow):
         self.api_client.setCurrentIndex(client_index if client_index >= 0 else 0)
         for key, checkbox in self.checks.items():
             checkbox.setChecked(bool(getattr(SETTINGS, key)))
+        self.request_interval.setValue(int(max(0, round(float(getattr(SETTINGS, 'requestIntervalSeconds', 1.0) or 0)))))
+        self._update_request_interval_enabled(self.checks["downloadDelay"].isChecked())
         self.album_format.setText(SETTINGS.albumFolderFormat)
         self.playlist_format.setText(SETTINGS.playlistFolderFormat)
         self.track_format.setText(SETTINGS.trackFileFormat)
@@ -945,6 +963,7 @@ class MainWindow(QMainWindow):
             "apiKeyIndex": self.api_client.currentData(),
         }
         values.update({key: checkbox.isChecked() for key, checkbox in self.checks.items()})
+        values["requestIntervalSeconds"] = float(self.request_interval.value())
         self.backend.save_settings(values)
         self.settings_status.setText("Settings saved.")
 
@@ -1070,8 +1089,16 @@ class MainWindow(QMainWindow):
         )
 
 
+def configure_application_theme(app: QApplication):
+    app.setStyle("Fusion")
+    hints = app.styleHints()
+    if hasattr(hints, "setColorScheme"):
+        hints.setColorScheme(Qt.ColorScheme.Light)
+
+
 def run_app(backend: TidekeeperBackend):
     app = QApplication.instance() or QApplication([])
+    configure_application_theme(app)
     backend.initialize()
     window = MainWindow(backend)
     window.show()

--- a/TIDALDL-PY/tidal_dl/gui_app/style.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/style.py
@@ -1,3 +1,6 @@
+TABLE_TEXT_COLOR = "#172033"
+TABLE_ALT_COLOR = "#f8fafc"
+
 APP_STYLESHEET = """
 * {
     font-family: "Segoe UI", "Inter", "Noto Sans", Arial, sans-serif;
@@ -220,5 +223,23 @@ QScrollBar::handle:vertical {
     background: #cbd5e1;
     border-radius: 6px;
     min-height: 24px;
+}
+
+QMenu, QMenuBar, QMenuBar::item {
+    background: #ffffff;
+    color: #172033;
+    border: 1px solid #e4e7ec;
+}
+
+QMenu::item:selected, QMenuBar::item:selected {
+    background: #dff3ec;
+    color: #0f172a;
+}
+
+QListView, QAbstractItemView {
+    background: #ffffff;
+    color: #172033;
+    selection-background-color: #dff3ec;
+    selection-color: #0f172a;
 }
 """

--- a/TIDALDL-PY/tidal_dl/lang/english.py
+++ b/TIDALDL-PY/tidal_dl/lang/english.py
@@ -44,6 +44,8 @@ class LangEnglish(object):
     SETTING_APIKEY = "APIKey support"
     SETTING_ADD_TYPE_FOLDER = "Add Type-Folder"
     SETTING_DOWNLOAD_DELAY = "Use Download Delay"
+    SETTING_REQUEST_INTERVAL_SECONDS = "Request delay seconds"
+    SETTING_SAVE_AS_FLAC = "Save FLAC as .flac files"
 
     CHOICE = "CHOICE"
     FUNCTION = "FUNCTION"
@@ -95,6 +97,8 @@ class LangEnglish(object):
     CHANGE_ADD_TYPE_FOLDER = "Add Type-Folder,eg Album/Video/Playlist('0'-No,'1'-Yes):"
     CHANGE_MULITHREAD_DOWNLOAD = "Multi thread download('0'-No,'1'-Yes):"
     CHANGE_USE_DOWNLOAD_DELAY = "Use Download Delay('0'-No,'1'-Yes):"
+    CHANGE_REQUEST_INTERVAL_SECONDS = "Request delay seconds (0=off, 30 or 60 can help rate limits):"
+    CHANGE_SAVE_AS_FLAC = "Save FLAC streams as .flac files when ffmpeg can remux them('0'-No,'1'-Yes):"
 
     # {} are required in these strings
     AUTH_START_LOGIN = "Starting login process..."

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -40,6 +40,9 @@ def __getExtension__(stream: StreamUrl):
     manifestMimeType = (stream.manifestMimeType or '').lower()
     codec = (stream.codec or '').lower()
 
+    if SETTINGS.saveAsFlac and 'flac' in codec:
+        return '.flac'
+
     if 'dash+xml' in manifestMimeType or 'mp4' in container:
         return '.m4a'
 

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -164,6 +164,8 @@ class Printf(object):
             [LANG.select.SETTING_MULITHREAD_DOWNLOAD, data.multiThread],
             [LANG.select.SETTING_APIKEY, f"[{data.apiKeyIndex}]" + apiKey.getItem(data.apiKeyIndex)['formats']],
             [LANG.select.SETTING_DOWNLOAD_DELAY, data.downloadDelay],
+            [getattr(LANG.select, "SETTING_REQUEST_INTERVAL_SECONDS", "Request delay seconds"), data.requestIntervalSeconds],
+            [getattr(LANG.select, "SETTING_SAVE_AS_FLAC", "Save FLAC as .flac files"), data.saveAsFlac],
         ])
         print(tb)
 

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -31,6 +31,8 @@ class Settings(aigpy.model.ModelBase):
     downloadVideos = True
     multiThread = False
     downloadDelay = True
+    requestIntervalSeconds = 1.0
+    saveAsFlac = False
 
     downloadPath = "./download/"
     audioQuality = AudioQuality.Normal
@@ -137,10 +139,17 @@ class Settings(aigpy.model.ModelBase):
             self.videoFileFormat = self.getDefaultPathFormat(Type.Video)
         if self.apiKeyIndex is None:
             self.apiKeyIndex = 0
+        if getattr(self, 'requestIntervalSeconds', None) is None:
+            self.requestIntervalSeconds = 1.0
+        else:
+            self.requestIntervalSeconds = max(0.0, float(self.requestIntervalSeconds))
+        if getattr(self, 'saveAsFlac', None) is None:
+            self.saveAsFlac = False
         if not hasSavedSettings:
             self.downloadPath = getDefaultDownloadPath()
 
         LANG.setLang(self.language)
+        syncPlaybackRateLimiter()
 
     def save(self):
         data = aigpy.model.modelToDict(self)
@@ -194,6 +203,15 @@ class TokenSettings(aigpy.model.ModelBase):
                 os.chmod(self._path_, 0o600)
             except OSError:
                 pass
+
+
+def syncPlaybackRateLimiter():
+    from .tidal import PLAYBACK_RATE_LIMITER
+
+    if SETTINGS.downloadDelay is False:
+        PLAYBACK_RATE_LIMITER.minInterval = 0.0
+        return
+    PLAYBACK_RATE_LIMITER.minInterval = max(0.0, float(getattr(SETTINGS, 'requestIntervalSeconds', 1.0) or 0.0))
 
 
 # Singleton

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -76,6 +76,21 @@ class TidalAPI(object):
         self.session.mount("https://", adapter)
         self.playbackRateLimiter = PLAYBACK_RATE_LIMITER
 
+    def __responseBody__(self, response):
+        try:
+            return response.json()
+        except ValueError:
+            return {}
+
+    def __isAssetNotReady__(self, response):
+        if response is None or response.status_code != 401:
+            return False
+        body = self.__responseBody__(response)
+        if body.get('subStatus') == 4005:
+            return True
+        message = str(body.get('userMessage', '')).lower()
+        return 'not ready for playback' in message
+
     def __responseErrorCodes__(self, response):
         try:
             data = response.json()
@@ -139,10 +154,13 @@ class TidalAPI(object):
         respond = None
         refreshedToken = False
         url = urlpre + path
-        for index in range(0, 3):
+        playbackRequest = "playbackinfopostpaywall" in url
+        maxAttempts = 6 if playbackRequest else 3
+        for index in range(0, maxAttempts):
             try:
                 header = {'authorization': f'Bearer {self.key.accessToken}'}
-                if "playbackinfopostpaywall" in url and SETTINGS.downloadDelay is not False:
+                if playbackRequest and SETTINGS.downloadDelay is not False:
+                    syncPlaybackRateLimiter()
                     self.playbackRateLimiter.wait()
 
                 respond = self.session.get(url, headers=header, params=params, timeout=REQUEST_TIMEOUT)
@@ -150,6 +168,13 @@ class TidalAPI(object):
                 if respond.status_code == 429:
                     delay = self.__retryAfter__(respond, index)
                     print(f"Too many requests, waiting {delay:g} seconds before retry.")
+                    time.sleep(delay)
+                    continue
+
+                if respond.status_code == 401 and self.__isAssetNotReady__(respond):
+                    delay = min(5 * (index + 1), 30)
+                    print(f"Asset not ready for playback, waiting {delay:g} seconds before retry.")
+                    respond.close()
                     time.sleep(delay)
                     continue
 
@@ -168,10 +193,10 @@ class TidalAPI(object):
                     errmsg += result['userMessage']
                 break
             except TidalApiError as e:
-                if index == 2:
+                if index >= maxAttempts - 1:
                     raise e
             except Exception as e:
-                if index == 2 and respond is not None:
+                if index >= maxAttempts - 1 and respond is not None:
                     errmsg += respond.text
 
         raise Exception(errmsg)


### PR DESCRIPTION
## Summary

This PR resolves all four currently open issues on the repository.

## Changes

### #11 GUI elements broken on Windows 11 dark theme
- Force Fusion style and light Qt color scheme so system dark mode cannot override the app stylesheet
- Set explicit foreground colors on table cells
- Add menu/list popup styling for readable dropdowns

### #12 Downloads as FLAC but saved as .m4a
- Add optional **Save FLAC as .flac files** setting (GUI + persisted settings)
- Use `.flac` extension when enabled and remux FLAC-in-M4A streams with `ffmpeg` when available

### #13 Manually configure interval between requests
- Add **Request interval** spin box (0–300 seconds) in GUI settings
- Persist `requestIntervalSeconds` and apply it to the playback API rate limiter when request delay is enabled

### #14 Can't download (asset not ready for playback)
- Retry `playbackinfopostpaywall` requests when TIDAL returns HTTP 401 / subStatus 4005 with exponential backoff (up to 6 attempts)

## Testing

- `python -m unittest discover -s tests` (88 tests, all passing)

## Closes

- Closes #11
- Closes #12
- Closes #13
- Closes #14