### PR TITLE
fix: resolve open issues #11, #12, #13, #14 (GUI dark theme, FLAC ext, configurable delay, download robustness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fixed downloads labeled FLAC saving with .m4a extension: now use .flac for FLAC codec (with optional ffmpeg remux from containerized DASH segments to produce valid standalone FLAC files; falls back gracefully).
+- Fixed GUI elements (menus, track lists, sections) invisible or white/blank on Windows 11 dark theme by forcing Fusion style + explicit light QPalette + expanded stylesheet rules.
+- Added configurable request delay interval (downloadDelaySec) to manually set seconds between audio stream requests, helping avoid Tidal rate limiting (CLI prompt, GUI spinbox, settings, dynamic rate limiter).
+- Improved vague "can't download" cases with better error hints in output (quality, network, permission, disk), Windows-specific doctor advice, and more actionable messages.
+- Updated tests, paths logic, GUI, CLI, backend, diagnostics, and docs accordingly.
 - Added video-only artist downloads in the terminal and desktop GUI.
 - Improved download reliability with resumable single-file downloads, safer final-file replacement, pooled HTTP sessions, token refresh retry on expired API calls, and reduced duplicate album/cover lookups.
 - Added a README GUI gallery with Search, Queue, Settings, and Account screenshots.

--- a/TIDALDL-PY/tests/test_paths.py
+++ b/TIDALDL-PY/tests/test_paths.py
@@ -6,14 +6,14 @@ from tidal_dl.paths import __getExtension__, getConfigDirectory, getPathSummary,
 
 
 class PathTests(unittest.TestCase):
-    def test_dash_flac_in_mp4_container_uses_m4a_extension(self):
+    def test_flac_codec_uses_flac_extension_even_for_dash_container(self):
         stream = StreamUrl()
         stream.url = "https://example.invalid/init.mp4"
         stream.codec = "flac"
         stream.manifestMimeType = "application/dash+xml"
         stream.container = "mp4"
 
-        self.assertEqual(__getExtension__(stream), ".m4a")
+        self.assertEqual(__getExtension__(stream), ".flac")
 
     def test_native_flac_url_uses_flac_extension(self):
         stream = StreamUrl()

--- a/TIDALDL-PY/tidal_dl/diagnostics.py
+++ b/TIDALDL-PY/tidal_dl/diagnostics.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 import os
 import shutil
+import sys
 
 import aigpy
 
@@ -69,6 +70,8 @@ def __checkToken__():
 
 def runDoctor():
     print("Tidekeeper doctor")
+    if sys.platform.startswith("win"):
+        Printf.info("Platform: Windows - common download issues: path permissions, long paths (>260 chars), antivirus blocking, or need to run terminal as normal user (not over-protected dirs).")
     checks = [
         __checkDownloadPath__(),
         __checkApiKey__(),

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import shutil
+import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock, local
@@ -364,6 +365,21 @@ def __isSkip__(finalpath, urls):
     return curSize >= netSize
 
 
+def __downloadErrorHint__(err: str) -> str:
+    e = (err or "").lower()
+    if any(x in e for x in ("403", "entitled", "not allowed", "client_not_entitled")):
+        return " (hint: quality not available for account/track; try lower --quality or set audioQualityPriority to fallback)"
+    if any(x in e for x in ("timeout", "connection", "network", "name or service not known")):
+        return " (hint: network/timeout; run 'tidekeeper --doctor', check internet/firewall/VPN/proxy)"
+    if any(x in e for x in ("permission", "denied", "access is denied", "readonly")):
+        return " (hint: download path permission issue on Windows; ensure folder writable, avoid protected dirs like C:\\, or try different downloadPath)"
+    if "disk" in e or "space" in e or "no space" in e:
+        return " (hint: disk full or quota)"
+    if "ffmpeg" in e and "video" in e:
+        return " (hint: video download may need ffmpeg installed)"
+    return ""
+
+
 def __encrypted__(stream, srcPath, descPath):
     if aigpy.string.isNull(stream.encryptionKey):
         os.replace(srcPath, descPath)
@@ -371,6 +387,47 @@ def __encrypted__(stream, srcPath, descPath):
         key, nonce = decrypt_security_token(stream.encryptionKey)
         decrypt_file(srcPath, descPath, key, nonce)
         os.remove(srcPath)
+
+
+def __isRawFlac__(path: str) -> bool:
+    try:
+        with open(path, "rb") as f:
+            return f.read(4) == b"fLaC"
+    except Exception:
+        return False
+
+
+def __remuxToFlac__(src: str, dst: str) -> bool:
+    """Remux audio (e.g. flac-in-mp4) to standalone .flac using ffmpeg -c copy."""
+    if not shutil.which("ffmpeg"):
+        return False
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        src,
+        "-c:a",
+        "copy",
+        "-f",
+        "flac",
+        dst,
+    ]
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=300,
+        )
+        return True
+    except Exception:
+        try:
+            if os.path.exists(dst):
+                os.remove(dst)
+        except Exception:
+            pass
+        return False
 
 
 def __lyricsText__(value):
@@ -768,11 +825,35 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         if not check:
             __removeFile__(partPath)
             __logFailedTrack__(track, album, playlist, err)
-            Printf.err(f"DL Track '{title}' failed: {str(err)}")
+            hint = __downloadErrorHint__(str(err))
+            Printf.err(f"DL Track '{title}' failed: {str(err)}{hint}")
             return False, str(err)
 
         # encrypted -> decrypt and remove encrypted file
         __encrypted__(stream, partPath, path)
+
+        # Ensure FLAC codec results in a proper .flac file (remux from mp4/dash
+        # container segments used by Tidal openapi lossless). Falls back to .m4a
+        # if ffmpeg not present (see doctor output).
+        final_path = path
+        try:
+            stream_codec = (getattr(stream, "codec", None) or "").lower()
+            if stream_codec in ("flac", "fLaC") and path.lower().endswith(".flac"):
+                if not __isRawFlac__(path):
+                    tmp = path + ".remux"
+                    if __remuxToFlac__(path, tmp):
+                        os.replace(tmp, path)
+                    else:
+                        m4a_path = path[:-5] + ".m4a"
+                        if os.path.exists(path):
+                            try:
+                                os.replace(path, m4a_path)
+                                final_path = m4a_path
+                                Printf.info("FLAC content saved as .m4a container (install ffmpeg for native .flac)")
+                            except Exception:
+                                pass
+        except Exception:
+            pass
 
         # contributors
         try:
@@ -780,12 +861,12 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         except:
             contributors = None
 
-        lyrics = __saveLyricsForTrack__(track, path)
+        lyrics = __saveLyricsForTrack__(track, final_path)
 
         try:
-            __setMetaData__(track, album, path, contributors, lyrics)
+            __setMetaData__(track, album, final_path, contributors, lyrics)
         except Exception as e:
-            logging.warning("Unable to write metadata for %s: %s", path, e)
+            logging.warning("Unable to write metadata for %s: %s", final_path, e)
             Printf.info(f"Downloaded '{title}', but metadata tagging was skipped: {str(e)}")
         Printf.success(title)
 
@@ -793,7 +874,8 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
     except Exception as e:
         __removeFile__(locals().get('partPath', ''))
         __logFailedTrack__(track, album, playlist, e)
-        Printf.err(f"DL Track '{title}' failed: {str(e)}")
+        hint = __downloadErrorHint__(str(e))
+        Printf.err(f"DL Track '{title}' failed: {str(e)}{hint}")
         return False, str(e)
 
 

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -198,6 +198,13 @@ def changeSettings():
     SETTINGS.multiThread = Printf.enterBool(LANG.select.CHANGE_MULITHREAD_DOWNLOAD)
     SETTINGS.usePlaylistFolder = Printf.enterBool(LANG.select.SETTING_USE_PLAYLIST_FOLDER + "('0'-No,'1'-Yes):")
     SETTINGS.downloadDelay = Printf.enterBool(LANG.select.CHANGE_USE_DOWNLOAD_DELAY)
+    try:
+        cur = getattr(SETTINGS, "downloadDelaySec", 1.0)
+        sec_str = Printf.enter((LANG.select.CHANGE_DOWNLOAD_DELAY_SEC or "Request delay seconds (e.g. 1 or 30):").format(cur))
+        sec = float(sec_str)
+        SETTINGS.downloadDelaySec = max(0.0, sec)
+    except Exception:
+        pass
     SETTINGS.language = Printf.enter(LANG.select.CHANGE_LANGUAGE + "(" + LANG.getLangChoicePrint() + "):")
     LANG.setLang(SETTINGS.language)
     SETTINGS.save()

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -318,6 +318,11 @@ class TidekeeperBackend:
         SETTINGS.downloadVideos = values["downloadVideos"]
         SETTINGS.multiThread = values["multiThread"]
         SETTINGS.downloadDelay = values["downloadDelay"]
+        if "downloadDelaySec" in values:
+            try:
+                SETTINGS.downloadDelaySec = float(values["downloadDelaySec"])
+            except Exception:
+                pass
         SETTINGS.usePlaylistFolder = values["usePlaylistFolder"]
         SETTINGS.showProgress = values["showProgress"]
         SETTINGS.showTrackInfo = values["showTrackInfo"]
@@ -405,6 +410,7 @@ class DemoBackend(TidekeeperBackend):
         SETTINGS.downloadVideos = False
         SETTINGS.multiThread = False
         SETTINGS.downloadDelay = True
+        SETTINGS.downloadDelaySec = 1.0
         SETTINGS.usePlaylistFolder = True
 
     def auth_status(self) -> AuthStatus:

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -4,11 +4,12 @@ import webbrowser
 from typing import Dict, List, Tuple
 
 from PySide6.QtCore import Qt, QThreadPool, QTimer
-from PySide6.QtGui import QTextCursor
+from PySide6.QtGui import QBrush, QColor, QPalette, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFileDialog,
     QFrame,
     QGridLayout,
@@ -360,6 +361,17 @@ class MainWindow(QMainWindow):
         ):
             self.checks[key] = QCheckBox(label)
 
+        self.delay_sec = QDoubleSpinBox()
+        self.delay_sec.setRange(0.0, 300.0)
+        self.delay_sec.setSingleStep(0.5)
+        self.delay_sec.setDecimals(1)
+        self.delay_sec.setSuffix(" s")
+        self.delay_sec.setToolTip(
+            "Interval (seconds) between each audio stream request. "
+            "Raise this (e.g. 5s or 30s) if Tidal rate limits your account. "
+            "0 disables the delay. Applies when 'Use request delay' is on."
+        )
+
         self.album_format = QLineEdit()
         self.playlist_format = QLineEdit()
         self.track_format = QLineEdit()
@@ -445,6 +457,9 @@ class MainWindow(QMainWindow):
             for row, key in enumerate(keys, start=1):
                 grid.addWidget(self.checks[key], row, column)
             grid.setColumnStretch(column, 1)
+        # delay seconds config (under run behavior)
+        grid.addWidget(_label("Request delay (sec)", "Muted"), 6, 2)
+        grid.addWidget(self.delay_sec, 7, 2)
         return _panel(grid)
 
     def _build_naming_settings_panel(self) -> QFrame:
@@ -874,6 +889,7 @@ class MainWindow(QMainWindow):
         self.api_client.setCurrentIndex(client_index if client_index >= 0 else 0)
         for key, checkbox in self.checks.items():
             checkbox.setChecked(bool(getattr(SETTINGS, key)))
+        self.delay_sec.setValue(float(getattr(SETTINGS, "downloadDelaySec", 1.0)))
         self.album_format.setText(SETTINGS.albumFolderFormat)
         self.playlist_format.setText(SETTINGS.playlistFolderFormat)
         self.track_format.setText(SETTINGS.trackFileFormat)
@@ -945,6 +961,7 @@ class MainWindow(QMainWindow):
             "apiKeyIndex": self.api_client.currentData(),
         }
         values.update({key: checkbox.isChecked() for key, checkbox in self.checks.items()})
+        values["downloadDelaySec"] = float(self.delay_sec.value())
         self.backend.save_settings(values)
         self.settings_status.setText("Settings saved.")
 
@@ -1072,6 +1089,28 @@ class MainWindow(QMainWindow):
 
 def run_app(backend: TidekeeperBackend):
     app = QApplication.instance() or QApplication([])
+    # Force Fusion style + explicit light palette so custom stylesheet
+    # (light panels, dark text) is respected on Windows 11 dark theme etc.
+    # This prevents system dark mode from making nav/text "all white" or
+    # sections invisible/blank.
+    app.setStyle("Fusion")
+    palette = QPalette()
+    # Window / base light bg
+    palette.setColor(QPalette.Window, QColor("#f5f7fb"))
+    palette.setColor(QPalette.WindowText, QColor("#172033"))
+    palette.setColor(QPalette.Base, QColor("#ffffff"))
+    palette.setColor(QPalette.AlternateBase, QColor("#f8fafc"))
+    palette.setColor(QPalette.Text, QColor("#172033"))
+    palette.setColor(QPalette.Button, QColor("#ffffff"))
+    palette.setColor(QPalette.ButtonText, QColor("#172033"))
+    palette.setColor(QPalette.Highlight, QColor("#0f766e"))
+    palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.ToolTipBase, QColor("#ffffff"))
+    palette.setColor(QPalette.ToolTipText, QColor("#172033"))
+    # Disabled
+    palette.setColor(QPalette.Disabled, QPalette.Text, QColor("#98a2b3"))
+    palette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor("#98a2b3"))
+    app.setPalette(palette)
     backend.initialize()
     window = MainWindow(backend)
     window.show()

--- a/TIDALDL-PY/tidal_dl/gui_app/style.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/style.py
@@ -5,6 +5,25 @@ APP_STYLESHEET = """
     letter-spacing: 0px;
 }
 
+/* Force light theme colors even if system (Win11 dark) tries to override */
+QWidget, QMainWindow, QFrame {
+    background-color: #f5f7fb;
+    color: #172033;
+}
+QWidget#Root, QMainWindow {
+    background: #f5f7fb;
+    color: #172033;
+}
+QMenu, QMenuBar {
+    background: #ffffff;
+    color: #172033;
+    border: 1px solid #e4e7ec;
+}
+QMenu::item:selected {
+    background: #dff3ec;
+    color: #0f172a;
+}
+
 QMainWindow, QWidget#Root {
     background: #f5f7fb;
     color: #172033;

--- a/TIDALDL-PY/tidal_dl/lang/english.py
+++ b/TIDALDL-PY/tidal_dl/lang/english.py
@@ -44,6 +44,7 @@ class LangEnglish(object):
     SETTING_APIKEY = "APIKey support"
     SETTING_ADD_TYPE_FOLDER = "Add Type-Folder"
     SETTING_DOWNLOAD_DELAY = "Use Download Delay"
+    SETTING_DOWNLOAD_DELAY_SEC = "Request delay seconds (between audio requests)"
 
     CHOICE = "CHOICE"
     FUNCTION = "FUNCTION"
@@ -95,6 +96,7 @@ class LangEnglish(object):
     CHANGE_ADD_TYPE_FOLDER = "Add Type-Folder,eg Album/Video/Playlist('0'-No,'1'-Yes):"
     CHANGE_MULITHREAD_DOWNLOAD = "Multi thread download('0'-No,'1'-Yes):"
     CHANGE_USE_DOWNLOAD_DELAY = "Use Download Delay('0'-No,'1'-Yes):"
+    CHANGE_DOWNLOAD_DELAY_SEC = "Request delay seconds (0.5-60 recommended; 0=off) (current {0}):"
 
     # {} are required in these strings
     AUTH_START_LOGIN = "Starting login process..."

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -40,6 +40,14 @@ def __getExtension__(stream: StreamUrl):
     manifestMimeType = (stream.manifestMimeType or '').lower()
     codec = (stream.codec or '').lower()
 
+    # Prefer raw extension based on codec for lossless etc. Dash/ mp4 container
+    # FLAC from openapi is often delivered as mp4-wrapped segments; remux in
+    # download.py turns it into proper .flac when ffmpeg is available.
+    if codec in ('flac', 'fLaC', 'FLAC'):
+        return '.flac'
+    if codec in ('ec-3', 'eac3', 'ac-3', 'aac'):
+        return '.m4a'
+
     if 'dash+xml' in manifestMimeType or 'mp4' in container:
         return '.m4a'
 

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -164,6 +164,7 @@ class Printf(object):
             [LANG.select.SETTING_MULITHREAD_DOWNLOAD, data.multiThread],
             [LANG.select.SETTING_APIKEY, f"[{data.apiKeyIndex}]" + apiKey.getItem(data.apiKeyIndex)['formats']],
             [LANG.select.SETTING_DOWNLOAD_DELAY, data.downloadDelay],
+            [LANG.select.SETTING_DOWNLOAD_DELAY_SEC or "Request delay (sec)", getattr(data, "downloadDelaySec", 1.0)],
         ])
         print(tb)
 

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -31,6 +31,7 @@ class Settings(aigpy.model.ModelBase):
     downloadVideos = True
     multiThread = False
     downloadDelay = True
+    downloadDelaySec = 1.0
 
     downloadPath = "./download/"
     audioQuality = AudioQuality.Normal

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -31,10 +31,23 @@ REQUEST_TIMEOUT = (5, 60)
 
 class RequestRateLimiter:
     def __init__(self, minInterval=1.0, jitter=0.5):
-        self.minInterval = minInterval
+        self._minInterval = minInterval
         self.jitter = jitter
         self._lock = Lock()
         self._nextAllowed = 0.0
+
+    @property
+    def minInterval(self):
+        try:
+            if hasattr(SETTINGS, "downloadDelaySec") and SETTINGS.downloadDelaySec is not None:
+                return max(0.0, float(SETTINGS.downloadDelaySec))
+        except Exception:
+            pass
+        return self._minInterval
+
+    @minInterval.setter
+    def minInterval(self, v):
+        self._minInterval = float(v) if v is not None else 1.0
 
     def wait(self):
         if self.minInterval <= 0:


### PR DESCRIPTION
This PR fixes all currently open issues in the repo:

- Fixes #11: GUI Elements Broken (white/invisible menus, blank track sections on Win11 dark theme). Force Qt Fusion style + explicit light palette + expanded stylesheet to ensure consistent light theme rendering independent of system theme.
- Fixes #12: Downloads as FLAC but file is .m4a. Updated extension selection to use .flac for flac codec (even dash/mp4 container). Added remux logic in download using ffmpeg -c copy when needed to produce valid standalone FLAC files; graceful fallback to .m4a + info message if no ffmpeg.
- Implements #13 (as feature): Manually configure interval between each request. Added `downloadDelaySec` setting (default 1.0s). Exposed in CLI `changeSettings`, GUI settings spinbox (0-300s), persisted, and rate limiter now reads it dynamically. Helps avoid Tidal rate limits.
- Addresses #14: [BUG] cant download (vague report). Added `__downloadErrorHint__` for actionable suggestions on common failures (403/entitle, network, perms esp. Windows, disk). Enhanced `tidekeeper --doctor` with Windows-specific troubleshooting notes. Better UX for "error and need help" cases.

Changes:
- Core: paths.py, download.py (remux+ext+hints), tidal.py (rate limiter), settings.py
- CLI: events.py, printf.py, lang/english.py
- GUI: main_window.py (palette, spin, load/save), style.py, backend.py
- Tests/docs: test_paths.py updated, CHANGELOG.md, diagnostics.py
- Verified: all 86 unit tests pass, manual logic checks, GUI imports.

All fixes made locally, tests ensure, PR via separate authed account (openclawed-007) per request.

Refs #11 #12 #13 #14