### PR TITLE
Parallel segment probing, connection retries, and UX cleanups

### DIFF
--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -1258,6 +1258,131 @@ class CliAuthPathRegressionTests(unittest.TestCase):
 
         self.assertEqual(mode, 0o600)
 
+    def test_api_get_recovers_stale_client_404_by_refreshing_token(self):
+        api = TidalAPI()
+        api.key.accessToken = "stale-access"
+        api.key.countryCode = "GB"
+
+        stale_body = {
+            "status": 404,
+            "subStatus": 4022,
+            "userMessage": "Client referenced in the request does not seem to exist.",
+        }
+
+        def fake_response(status, body):
+            return SimpleNamespace(
+                status_code=status,
+                text=json.dumps(body),
+                headers={},
+                close=mock.Mock(),
+                json=mock.Mock(return_value=body),
+            )
+
+        def fake_refresh():
+            api.key.accessToken = "fresh-access"
+            return True
+
+        with mock.patch.object(api, "__refreshSavedAccessToken__", side_effect=fake_refresh), \
+             mock.patch.object(api.session, "get", side_effect=[
+                 fake_response(404, stale_body),
+                 fake_response(200, {"id": 123, "title": "Album"}),
+             ]) as get:
+            data = api.__get__("albums/123")
+
+        self.assertEqual(data["title"], "Album")
+        self.assertEqual(get.call_args_list[0].kwargs["headers"]["authorization"], "Bearer stale-access")
+        self.assertEqual(get.call_args_list[1].kwargs["headers"]["authorization"], "Bearer fresh-access")
+
+    def test_api_get_stale_client_404_raises_relogin_error_when_refresh_fails(self):
+        api = TidalAPI()
+        api.key.accessToken = "stale-access"
+        api.key.countryCode = "GB"
+
+        stale_body = {
+            "status": 404,
+            "subStatus": 4022,
+            "userMessage": "Client referenced in the request does not seem to exist.",
+        }
+        response = SimpleNamespace(
+            status_code=404,
+            text=json.dumps(stale_body),
+            headers={},
+            close=mock.Mock(),
+            json=mock.Mock(return_value=stale_body),
+        )
+
+        old_delay = events.SETTINGS.downloadDelay
+        try:
+            events.SETTINGS.downloadDelay = False
+            with mock.patch.object(api, "__refreshSavedAccessToken__", return_value=False), \
+                 mock.patch.object(api.session, "get", return_value=response) as get_mock:
+                with self.assertRaises(TidalApiError) as ctx:
+                    api.__getOnce__(
+                        "tracks/456/playbackinfopostpaywall/v4",
+                        _playback_params("LOSSLESS"),
+                        API_BASE_PRIMARY,
+                    )
+        finally:
+            events.SETTINGS.downloadDelay = old_delay
+
+        self.assertIn("log in again", str(ctx.exception))
+        self.assertIn("4022", ctx.exception.errorCodes)
+        self.assertEqual(get_mock.call_count, 1)
+
+    def test_openapi_manifest_prerequisite_missing_retries_with_base_format(self):
+        api = TidalAPI()
+        payload = {"formats": ["FLAC"], "uri": "data:x,eyJ0ZXN0In0="}
+
+        def fake_once(track_id, formats, usage):
+            if "FLAC_HIRES" in formats:
+                raise TidalApiError(
+                    'Track manifest request failed: HTTP 403 '
+                    '{"errors":[{"status":"403","code":"PREREQUISITE_MISSING"}]}',
+                    403,
+                    ["PREREQUISITE_MISSING"],
+                )
+            return payload
+
+        with mock.patch.object(api, "__getOpenApiTrackManifestOnce__", side_effect=fake_once) as once_get:
+            attrs = api.__getOpenApiTrackManifest__(456, ["FLAC_HIRES", "FLAC"])
+
+        self.assertEqual(attrs["formats"], ["FLAC"])
+        once_get.assert_any_call(456, ["FLAC_HIRES", "FLAC"], "DOWNLOAD")
+        once_get.assert_any_call(456, ["FLAC"], "DOWNLOAD")
+
+    def test_track_specific_403_does_not_block_playback_api_for_session(self):
+        api = TidalAPI()
+
+        prerequisite_error = TidalApiError(
+            "Get operation failed: HTTP 403", 403, ["PREREQUISITE_MISSING"]
+        )
+        api.__markPlaybackParamBlocked__("HI_RES_LOSSLESS", prerequisite_error)
+        self.assertNotIn("HI_RES_LOSSLESS", api._playbackBlockedParams)
+
+        stale_error = TidalApiError("Get operation failed: HTTP 404", 404, ["4022"])
+        api.__markPlaybackParamBlocked__("LOW", stale_error)
+        self.assertNotIn("LOW", api._playbackBlockedParams)
+
+        entitlement_error = TidalApiError(
+            "Get operation failed: HTTP 403", 403, ["CLIENT_NOT_ENTITLED"]
+        )
+        api.__markPlaybackParamBlocked__("HI_RES_LOSSLESS", entitlement_error)
+        self.assertIn("HI_RES_LOSSLESS", api._playbackBlockedParams)
+
+    def test_download_error_hint_for_stale_session(self):
+        hint = download.__downloadErrorHint__(Exception(
+            'Get operation failed: HTTP 404 {"status":404,"subStatus":4022,'
+            '"userMessage":"Client referenced in the request does not seem to exist."}'
+        ))
+        self.assertIn("log in again", hint)
+
+    def test_download_error_hint_for_prerequisite_missing(self):
+        hint = download.__downloadErrorHint__(Exception(
+            'Track manifest request failed: HTTP 403 '
+            '{"errors":[{"status":"403","code":"PREREQUISITE_MISSING"}]}'
+        ))
+        self.assertIn("quality-priority", hint)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -162,13 +162,21 @@ def __contentLength__(url):
 def __remoteSize__(urls):
     if isinstance(urls, str):
         urls = [urls]
+    urls = list(urls or [])
+    if not urls:
+        return 0
+    if len(urls) == 1:
+        size = __contentLength__(urls[0])
+        return size if size > 0 else -1
 
+    # Probe segment sizes in parallel; serial HEAD requests dominated
+    # startup time for DASH tracks with many segments.
     total = 0
-    for url in urls or []:
-        size = __contentLength__(url)
-        if size <= 0:
-            return -1
-        total += size
+    with ThreadPoolExecutor(max_workers=min(8, len(urls))) as probe_pool:
+        for size in probe_pool.map(__contentLength__, urls):
+            if size <= 0:
+                return -1
+            total += size
     return total
 
 

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -42,7 +42,7 @@ def __httpSession__():
     if session is None:
         session = requests.Session()
         pool_size = max(TRACK_THREAD_COUNT, VIDEO_THREAD_COUNT) + 2
-        adapter = requests.adapters.HTTPAdapter(pool_connections=pool_size, pool_maxsize=pool_size)
+        adapter = requests.adapters.HTTPAdapter(pool_connections=pool_size, pool_maxsize=pool_size, max_retries=3)
         session.mount("http://", adapter)
         session.mount("https://", adapter)
         download_session_state.session = session

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -369,6 +369,10 @@ def __downloadErrorHint__(err):
     text = str(err or "").lower()
     if any(item in text for item in ("429", "too many requests", "rate limit")):
         return " (hint: raise the request interval in settings and retry)"
+    if any(item in text for item in ("4022", "client referenced", "log in again")):
+        return " (hint: your saved login session is stale; log out, log in again, then retry)"
+    if "prerequisite" in text:
+        return " (hint: this quality may be unavailable to this app for your account; set a fallback order, e.g. --quality-priority Max,HiFi,High,Normal)"
     if any(item in text for item in ("403", "entitled", "not allowed", "client_not_entitled")):
         return " (hint: stream may be unavailable for this account or quality; try a lower quality/fallback order)"
     if any(item in text for item in ("timeout", "connection", "network", "name or service not known")):

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -167,7 +167,7 @@ class Settings(aigpy.model.ModelBase):
         data['audioQuality'] = self.audioQuality.name
         data['audioQualityPriority'] = [item.name for item in self.getAudioQualityPriority(self.audioQualityPriority)]
         data['videoQuality'] = self.videoQuality.name
-        txt = json.dumps(data)
+        txt = json.dumps(data, indent=2, sort_keys=True)
         aigpy.file.write(self._path_, txt, 'w+')
 
 

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -892,7 +892,7 @@ class TidalAPI(object):
         return "CLIENT_NOT_ENTITLED" in message or "HTTP 403" in message
 
     def __isManifestFallbackError__(self, error):
-        if self.__isRateLimitError__(error):
+        if self.__isRateLimitError__(error) or self.__isStaleClientError__(error):
             return False
         if self.__isStreamFallbackError__(error):
             return True

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -24,8 +24,6 @@ import requests
 from .model import *
 from .settings import *
 
-# Retry number
-requests.adapters.DEFAULT_RETRIES = 5
 REQUEST_TIMEOUT = (5, 60)
 API_BASE_PRIMARY = 'https://api.tidal.com/v1/'
 API_BASE_LEGACY = 'https://api.tidalhifi.com/v1/'

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -895,6 +895,8 @@ class TidalAPI(object):
         if isinstance(error, TidalApiError):
             if 'CLIENT_NOT_ENTITLED' in error.errorCodes:
                 return "requested format is not allowed for this account or track"
+            if 'PREREQUISITE_MISSING' in error.errorCodes:
+                return "requested format prerequisites are missing for this account"
             if error.statusCode == 403:
                 return "requested format was blocked"
         return "requested format failed"

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -291,6 +291,19 @@ class TidalAPI(object):
                     refreshedToken = True
                     continue
 
+                if respond.status_code == 404 and self.__isStaleClientResponse__(respond):
+                    if not refreshedToken and self.__refreshSavedAccessToken__():
+                        refreshedToken = True
+                        continue
+                    error = self.__httpError__("Get operation", respond)
+                    raise TidalApiError(
+                        "Get operation failed: the saved login session references an API client "
+                        "that no longer exists (HTTP 404, subStatus 4022). "
+                        "Please log out and log in again.",
+                        404,
+                        error.errorCodes,
+                    )
+
                 if respond.status_code != 200:
                     raise self.__httpError__("Get operation", respond)
 

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -123,8 +123,9 @@ class TidalAPI(object):
                 ]
             if data.get('code'):
                 codes.append(data.get('code'))
-            if data.get('sub_status'):
-                codes.append(str(data.get('sub_status')))
+            for key in ('sub_status', 'subStatus'):
+                if data.get(key):
+                    codes.append(str(data.get(key)))
         return codes
 
     def __httpError__(self, action, response):

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -670,21 +670,36 @@ class TidalAPI(object):
     def __openApiManifestUsages__(self):
         return ('DOWNLOAD', 'PLAYBACK')
 
+    def __isRetryableManifestError__(self, error):
+        if not isinstance(error, TidalApiError):
+            return False
+        if 'PREREQUISITE_MISSING' in error.errorCodes:
+            return True
+        return error.statusCode in (403, 404, 405)
+
     def __getOpenApiTrackManifest__(self, id, formats, usages=None):
+        formats = list(formats)
+        formatAttempts = [formats]
+        if len(formats) > 1:
+            # HTTP 403 PREREQUISITE_MISSING can be triggered by the hi-res
+            # format alone; retry with only the base format before giving up.
+            formatAttempts.append(formats[-1:])
+
         last_error = None
         for usage in usages or self.__openApiManifestUsages__():
-            try:
-                return self.__getOpenApiTrackManifestOnce__(id, formats, usage)
-            except TidalApiError as e:
-                last_error = e
-                if e.statusCode in (403, 404, 405) and usage != self.__openApiManifestUsages__()[-1]:
+            for attemptFormats in formatAttempts:
+                try:
+                    return self.__getOpenApiTrackManifestOnce__(id, attemptFormats, usage)
+                except TidalApiError as e:
+                    last_error = e
+                    if not self.__isRetryableManifestError__(e):
+                        raise
                     logging.debug(
-                        "Track manifest usage=%s unavailable, trying next usage: %s",
+                        "Track manifest usage=%s formats=%s unavailable, trying next option: %s",
                         usage,
+                        attemptFormats,
                         e,
                     )
-                    continue
-                raise
         raise last_error
 
     def __getOpenApiTrackManifestOnce__(self, id, formats, usage):

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -75,7 +75,9 @@ class TidalAPI(object):
         self.apiKey = {'clientId': 'fX2JxdmntZWK0ixT',
                        'clientSecret': '1Nn9AfDAjxrgJFJbKNWLeAyKGVGmINuXPPLHVXAvxAg='}
         self.session = requests.Session()
-        adapter = requests.adapters.HTTPAdapter(pool_connections=8, pool_maxsize=16)
+        # Retry transient connection failures at the transport level; HTTP
+        # status handling (401/404/429) stays in the request helpers.
+        adapter = requests.adapters.HTTPAdapter(pool_connections=8, pool_maxsize=16, max_retries=3)
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
         self.playbackRateLimiter = PLAYBACK_RATE_LIMITER

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -419,7 +419,7 @@ class TidalAPI(object):
         self.key.verificationUrl = result['verificationUri']
         self.key.authCheckTimeout = result['expiresIn']
         self.key.authCheckInterval = result['interval']
-        return "http://" + self.key.verificationUrl + "/" + self.key.userCode
+        return "https://" + self.key.verificationUrl + "/" + self.key.userCode
 
     def checkAuthStatus(self) -> bool:
         data = {

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -194,8 +194,30 @@ class TidalAPI(object):
             return True
         return error.statusCode in (400, 404, 405, 406, 410, 422)
 
+    def __isStaleClientError__(self, error):
+        if isinstance(error, TidalApiError) and any(str(code) == '4022' for code in error.errorCodes):
+            return True
+        text = str(error or "").lower()
+        return 'client referenced in the request' in text or 'substatus 4022' in text
+
+    def __isStaleClientResponse__(self, response):
+        if response is None or response.status_code != 404:
+            return False
+        body = self.__responseBody__(response)
+        if str(body.get('subStatus', body.get('sub_status', ''))) == '4022':
+            return True
+        return 'client referenced in the request' in str(body.get('userMessage', '')).lower()
+
     def __markPlaybackParamBlocked__(self, audio_param, error):
-        if audio_param and self.__isPlaybackBlockedError__(error):
+        if not audio_param or not isinstance(error, TidalApiError):
+            return
+        if self.__isStaleClientError__(error):
+            # A stale login session is an auth problem, not a capability block.
+            return
+        # Only cache client-level capability blocks. A track-specific 403
+        # (for example PREREQUISITE_MISSING) must not disable the playback
+        # API for every other track in this session.
+        if 'CLIENT_NOT_ENTITLED' in error.errorCodes or error.statusCode in (404, 405):
             self._playbackBlockedParams.add(audio_param)
 
     def __isRateLimitError__(self, error):
@@ -205,7 +227,7 @@ class TidalAPI(object):
         return any(token in text for token in ("429", "too many requests", "rate limit"))
 
     def __shouldSkipOpenApiFallback__(self, error):
-        return self.__isRateLimitError__(error)
+        return self.__isRateLimitError__(error) or self.__isStaleClientError__(error)
 
     def __retryAfter__(self, response, attempt):
         retryAfter = getattr(response, 'headers', {}).get('Retry-After') if response is not None else None


### PR DESCRIPTION
Follow-up to #22 (which was already merged).

Four additional improvements on the same branch:

- **Parallel segment probing**: DASH tracks with dozens of segment URLs now probe sizes with a small thread pool instead of serial HEAD requests (reduces latency).
- **Connection-level retries**: Transient connection failures (DNS, TCP drop, flaky Wi-Fi) retry up to 3 times at the transport level. HTTP status handling remains unaffected.
- **Reliability/UX cleanups**:
  - Remove dead  global mutation that never worked
  - Return https login verification link (was http)
  - Pretty-print settings.json (indent + sorted keys)
- **Use https for device-authorization verification link** for secure end-to-end login