### PR TITLE
GUI queue UX fixes, queue cancellation, and backend hardening

### DIFF
--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -674,12 +674,8 @@ def __parseContributors__(roleType, Contributors):
     if Contributors is None:
         return None
     try:
-        ret = []
-        for item in Contributors['items']:
-            if item['role'] == roleType:
-                ret.append(item['name'])
-        return ret
-    except:
+        return [item['name'] for item in Contributors['items'] if item['role'] == roleType]
+    except (KeyError, TypeError):
         return None
 
 
@@ -704,16 +700,16 @@ def __setMetaData__(track: Track, album: Album, filepath, contributors, lyrics):
     obj.album = track.album.title
     obj.title = track.title
     if not aigpy.string.isNull(track.version):
-        obj.title += ' (' + track.version + ')'
+        obj.title += f' ({track.version})'
 
-    obj.artist = list(map(lambda artist: artist.name, track.artists))
+    obj.artist = [artist.name for artist in track.artists]
     obj.copyright = track.copyRight
     obj.tracknumber = track.trackNumber
     obj.discnumber = track.volumeNumber
     obj.composer = __parseContributors__('Composer', contributors)
     obj.isrc = track.isrc
 
-    obj.albumartist = list(map(lambda artist: artist.name, album.artists))
+    obj.albumartist = [artist.name for artist in album.artists]
     obj.date = album.releaseDate
     obj.totaldisc = album.numberOfVolumes
     obj.lyrics = lyrics
@@ -750,28 +746,29 @@ def downloadAlbumInfo(album, tracks):
     aigpy.path.mkdirs(path)
 
     path += '/AlbumInfo.txt'
-    infos = ""
-    infos += "[ID]          %s\n" % (str(album.id))
-    infos += "[Title]       %s\n" % (str(album.title))
-    infos += "[Artists]     %s\n" % (TIDAL_API.getArtistsName(album.artists))
-    infos += "[ReleaseDate] %s\n" % (str(album.releaseDate))
-    infos += "[SongNum]     %s\n" % (str(album.numberOfTracks))
-    infos += "[Duration]    %s\n" % (str(album.duration))
-    infos += '\n'
+    infos = (
+        f"[ID]          {album.id}\n"
+        f"[Title]       {album.title}\n"
+        f"[Artists]     {TIDAL_API.getArtistsName(album.artists)}\n"
+        f"[ReleaseDate] {album.releaseDate}\n"
+        f"[SongNum]     {album.numberOfTracks}\n"
+        f"[Duration]    {album.duration}\n"
+        "\n"
+    )
 
-    for index in range(0, album.numberOfVolumes):
+    for index in range(album.numberOfVolumes):
         volumeNumber = index + 1
         infos += f"===========CD {volumeNumber}=============\n"
         for item in tracks:
             if item.volumeNumber != volumeNumber:
                 continue
-            infos += '{:<8}'.format("[%d]" % item.trackNumber)
-            infos += "%s\n" % item.title
+            infos += f"{f'[{item.trackNumber}]':<8}{item.title}\n"
     aigpy.file.write(path, infos, "w+")
 
 
 def downloadVideo(video: Video, album: Album = None, playlist: Playlist = None):
     title = getattr(video, 'title', None) or str(getattr(video, 'id', 'unknown'))
+    partPath = ''
     try:
         stream = TIDAL_API.getVideoStreamUrl(video.id, SETTINGS.videoQuality)
         path = getVideoPath(video, album, playlist)
@@ -813,7 +810,7 @@ def downloadVideo(video: Video, album: Album = None, playlist: Playlist = None):
             Printf.err(f"DL Video[{title}] failed.{msg}")
             return False, msg
     except Exception as e:
-        __removeFile__(locals().get('partPath', ''))
+        __removeFile__(partPath)
         Printf.err(f"DL Video[{title}] failed.{str(e)}")
         return False, str(e)
 
@@ -832,6 +829,7 @@ def __ensureTrackStreamable__(track):
 
 def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, partSize=DEFAULT_PART_SIZE):
     title = getattr(track, 'title', None) or str(getattr(track, 'id', 'unknown'))
+    partPath = ''
     try:
         __ensureTrackStreamable__(track)
         stream = __getTrackStream__(track.id)
@@ -879,7 +877,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
         # contributors
         try:
             contributors = TIDAL_API.getTrackContributors(track.id)
-        except:
+        except Exception:
             contributors = None
 
         lyrics = __saveLyricsForTrack__(track, path)
@@ -893,7 +891,7 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
 
         return True, ''
     except Exception as e:
-        __removeFile__(locals().get('partPath', ''))
+        __removeFile__(partPath)
         __logFailedTrack__(track, album, playlist, e)
         Printf.err(f"DL Track '{title}' failed: {str(e)}{__downloadErrorHint__(e)}")
         return False, str(e)

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -113,6 +113,12 @@ def start(string, videoOnly=False):
         Printf.err('Please enter something.')
         return
 
+    # Treat the whole input as a single token first so file paths that
+    # contain spaces are not split apart.
+    if os.path.exists(string.strip()):
+        start_file(string.strip(), videoOnly)
+        return
+
     strings = string.split(" ")
     for item in strings:
         if aigpy.string.isNull(item):
@@ -317,7 +323,7 @@ def loginByConfig():
             return True
 
         Printf.info(LANG.select.MSG_INVALID_ACCESSTOKEN)
-        if TIDAL_API.refreshAccessToken(TOKEN.refreshToken):
+        if not aigpy.string.isNull(TOKEN.refreshToken) and TIDAL_API.refreshAccessToken(TOKEN.refreshToken):
             Printf.success(LANG.select.MSG_VALID_ACCESSTOKEN.format(
                 __displayTime__(int(TIDAL_API.key.expiresIn))))
 

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -826,6 +826,7 @@ class MainWindow(QMainWindow):
         self.download_log.append("Starting downloads")
         worker = DownloadWorker(self.backend, items)
         worker.signals.log.connect(self.append_download_log)
+        worker.signals.item_status.connect(self._set_queue_item_status)
         worker.signals.result.connect(lambda _: self.queue_status.setText("Downloads finished."))
         worker.signals.error.connect(self.show_download_error)
         worker.signals.finished.connect(self._download_finished)
@@ -834,6 +835,14 @@ class MainWindow(QMainWindow):
     def _download_finished(self):
         self.download_in_progress = False
         self.update_action_states()
+
+    def _set_queue_item_status(self, item, status: str):
+        for row in range(self.queue_table.rowCount()):
+            if self._row_item(self.queue_table, row) is item:
+                cell = self.queue_table.item(row, 4)
+                if cell is not None:
+                    cell.setText(status)
+                break
 
     def update_action_states(self):
         self.update_search_action()
@@ -1040,14 +1049,20 @@ class MainWindow(QMainWindow):
         self.account_log.append("Logged out.")
 
     def login_with_token(self):
+        access_token = self.access_token.text().strip()
+        if not access_token:
+            self.account_log.append("Enter an access token first.")
+            return
+        self.token_login_button.setEnabled(False)
         self.account_log.append("Saving manual token...")
         worker = TaskWorker(
             self.backend.login_by_access_token,
-            self.access_token.text(),
+            access_token,
             self.refresh_token.text(),
         )
         worker.signals.result.connect(lambda status: (self.refresh_auth_status(), self.account_log.append(status.label)))
         worker.signals.error.connect(lambda message: self.account_log.append(message))
+        worker.signals.finished.connect(lambda: self.token_login_button.setEnabled(True))
         self.start_worker(worker)
 
     def run_doctor(self):

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -100,6 +100,8 @@ class MainWindow(QMainWindow):
         self.login_poll_inflight = False
         self.search_in_progress = False
         self.download_in_progress = False
+        self.download_worker = None
+        self._cancel_requested = False
 
         self.setWindowTitle("Tidekeeper")
         self.setMinimumSize(1040, 680)
@@ -285,15 +287,19 @@ class MainWindow(QMainWindow):
         action_layout.addWidget(self.queue_status, 1)
         self.remove_queue_button = _button("Remove")
         self.clear_queue_button = _button("Clear")
+        self.cancel_queue_button = _button("Cancel", danger=True)
         self.start_queue_button = _button("Start Queue", primary=True)
         self.remove_queue_button.setToolTip("Remove selected queue rows.")
         self.clear_queue_button.setToolTip("Clear the queue and output log.")
+        self.cancel_queue_button.setToolTip("Stop after the current item finishes.")
         self.start_queue_button.setToolTip("Download every queued item.")
         self.remove_queue_button.clicked.connect(self.remove_selected_queue_items)
         self.clear_queue_button.clicked.connect(self.clear_queue)
+        self.cancel_queue_button.clicked.connect(self.cancel_downloads)
         self.start_queue_button.clicked.connect(self.start_queue_download)
         action_layout.addWidget(self.remove_queue_button)
         action_layout.addWidget(self.clear_queue_button)
+        action_layout.addWidget(self.cancel_queue_button)
         action_layout.addWidget(self.start_queue_button)
         layout.addLayout(action_layout)
 
@@ -822,9 +828,11 @@ class MainWindow(QMainWindow):
             self.queue_status.setText("A download is already running.")
             return
         self.download_in_progress = True
+        self._cancel_requested = False
         self.update_action_states()
         self.download_log.append("Starting downloads")
         worker = DownloadWorker(self.backend, items)
+        self.download_worker = worker
         worker.signals.log.connect(self.append_download_log)
         worker.signals.item_status.connect(self._set_queue_item_status)
         worker.signals.result.connect(lambda _: self.queue_status.setText("Downloads finished."))
@@ -834,7 +842,19 @@ class MainWindow(QMainWindow):
 
     def _download_finished(self):
         self.download_in_progress = False
+        self.download_worker = None
+        if self._cancel_requested:
+            self._cancel_requested = False
+            self.queue_status.setText("Downloads cancelled.")
         self.update_action_states()
+
+    def cancel_downloads(self):
+        if self.download_worker is None:
+            return
+        self._cancel_requested = True
+        self.download_worker.cancel()
+        self.cancel_queue_button.setEnabled(False)
+        self.queue_status.setText("Cancelling after the current item...")
 
     def _set_queue_item_status(self, item, status: str):
         for row in range(self.queue_table.rowCount()):
@@ -877,6 +897,7 @@ class MainWindow(QMainWindow):
         has_selection = bool(self.queue_table.selectionModel().selectedRows())
         self.remove_queue_button.setEnabled(has_selection and not self.download_in_progress)
         self.clear_queue_button.setEnabled(has_queue and not self.download_in_progress)
+        self.cancel_queue_button.setEnabled(self.download_in_progress and not self._cancel_requested)
         self.start_queue_button.setEnabled(has_queue and not self.download_in_progress)
 
     def append_download_log(self, text: str):

--- a/TIDALDL-PY/tidal_dl/gui_app/workers.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/workers.py
@@ -8,6 +8,7 @@ class WorkerSignals(QObject):
     error = Signal(str)
     finished = Signal()
     log = Signal(str)
+    item_status = Signal(object, str)
 
 
 class TaskWorker(QRunnable):
@@ -40,12 +41,28 @@ class DownloadWorker(QRunnable):
 
     @Slot()
     def run(self):
+        failed = []
         try:
             for item in self.items:
+                self.signals.item_status.emit(item, "Downloading")
                 self.signals.log.emit(f"Starting {item.title}\n")
-                self.backend.download(item, self.signals.log.emit)
+                try:
+                    self.backend.download(item, self.signals.log.emit)
+                except Exception as exc:
+                    failed.append(item.title)
+                    self.signals.item_status.emit(item, "Failed")
+                    self.signals.log.emit(f"Failed {item.title}: {exc}\n")
+                    continue
+                self.signals.item_status.emit(item, "Done")
                 self.signals.log.emit(f"Finished {item.title}\n")
-            self.signals.result.emit(self.items)
+            if failed:
+                shown = ", ".join(failed[:5])
+                more = f" (+{len(failed) - 5} more)" if len(failed) > 5 else ""
+                self.signals.error.emit(
+                    f"{len(failed)} download{'s' if len(failed) != 1 else ''} failed: {shown}{more}"
+                )
+            else:
+                self.signals.result.emit(self.items)
         except Exception as exc:
             self.signals.error.emit(str(exc))
         finally:

--- a/TIDALDL-PY/tidal_dl/gui_app/workers.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/workers.py
@@ -38,12 +38,21 @@ class DownloadWorker(QRunnable):
         self.backend = backend
         self.items = items
         self.signals = WorkerSignals()
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
 
     @Slot()
     def run(self):
         failed = []
+        cancelled = False
         try:
             for item in self.items:
+                if self._cancelled:
+                    cancelled = True
+                    self.signals.item_status.emit(item, "Cancelled")
+                    continue
                 self.signals.item_status.emit(item, "Downloading")
                 self.signals.log.emit(f"Starting {item.title}\n")
                 try:
@@ -55,13 +64,15 @@ class DownloadWorker(QRunnable):
                     continue
                 self.signals.item_status.emit(item, "Done")
                 self.signals.log.emit(f"Finished {item.title}\n")
+            if cancelled:
+                self.signals.log.emit("Remaining downloads cancelled.\n")
             if failed:
                 shown = ", ".join(failed[:5])
                 more = f" (+{len(failed) - 5} more)" if len(failed) > 5 else ""
                 self.signals.error.emit(
                     f"{len(failed)} download{'s' if len(failed) != 1 else ''} failed: {shown}{more}"
                 )
-            else:
+            elif not cancelled:
                 self.signals.result.emit(self.items)
         except Exception as exc:
             self.signals.error.emit(str(exc))

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -188,7 +188,7 @@ class TokenSettings(aigpy.model.ModelBase):
             sr = base64.b64decode(string)
             st = sr.decode()
             return st
-        except:
+        except (ValueError, UnicodeDecodeError):
             return string
 
     def read(self, path):

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -450,8 +450,12 @@ class TidalAPI(object):
         return True
 
     def verifyAccessToken(self, accessToken) -> bool:
-        header = {'authorization': 'Bearer {}'.format(accessToken)}
-        result = self.session.get('https://api.tidal.com/v1/sessions', headers=header, timeout=REQUEST_TIMEOUT).json()
+        header = {'authorization': f'Bearer {accessToken}'}
+        try:
+            response = self.session.get('https://api.tidal.com/v1/sessions', headers=header, timeout=REQUEST_TIMEOUT)
+            result = response.json()
+        except (requests.RequestException, ValueError):
+            return False
 
         if 'status' in result and result['status'] != 200:
             return False
@@ -479,8 +483,12 @@ class TidalAPI(object):
         return True
 
     def loginByAccessToken(self, accessToken, userid=None):
-        header = {'authorization': 'Bearer {}'.format(accessToken)}
-        result = self.session.get('https://api.tidal.com/v1/sessions', headers=header, timeout=REQUEST_TIMEOUT).json()
+        header = {'authorization': f'Bearer {accessToken}'}
+        response = self.session.get('https://api.tidal.com/v1/sessions', headers=header, timeout=REQUEST_TIMEOUT)
+        try:
+            result = response.json()
+        except ValueError:
+            raise Exception(f"Login failed: unexpected HTTP {response.status_code} response from TIDAL.")
         if 'status' in result and result['status'] != 200:
             raise Exception("Login failed!")
 
@@ -1063,7 +1071,7 @@ class TidalAPI(object):
         url = self.getCoverUrl(sid, width, height)
         try:
             return self.session.get(url, timeout=REQUEST_TIMEOUT).content
-        except:
+        except requests.RequestException:
             return ''
 
     def getArtistsName(self, artists=[]):
@@ -1123,7 +1131,11 @@ class TidalAPI(object):
             try:
                 obj = self.getTypeData(sid, item)
                 return item, obj
-            except:
+            except Exception as e:
+                # Surface session and throttling problems instead of
+                # masking them as a generic "No result." while probing types.
+                if self.__isRateLimitError__(e) or self.__isStaleClientError__(e):
+                    raise
                 continue
 
         raise Exception("No result.")


### PR DESCRIPTION
Includes all updates from the `testmain4/tidekeeper` repo.

### Fix GUI queue UX issues and modernize outdated code
- Continue queue downloads when a single item fails and report failures
- Show live per-item status (Downloading/Done/Failed) in the queue table
- Validate empty access token and disable Save Token button while saving
- Replace bare except clauses with specific exception handling
- Replace fragile locals().get() cleanup with explicit initialization
- Replace %-formatting and list(map(lambda)) with f-strings/comprehensions

### Harden backend reliability and add queue cancellation
- Treat whole input as a file path first so paths with spaces work
- Propagate rate-limit and stale-session errors in getByString
- Handle non-JSON responses in verifyAccessToken/loginByAccessToken
- Skip token refresh attempt when no refresh token is saved
- Narrow bare except in getCoverData to requests.RequestException
- **Add cooperative cancellation to DownloadWorker with a Cancel button in the queue page**