### PR TITLE
Fix error masking in API retry loop and clean up dead code

### DIFF
--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -9,6 +9,8 @@
 @Desc    :
 """
 
+import logging
+
 from .download import *
 
 '''
@@ -339,6 +341,7 @@ def loginByConfig():
             logout()
             return False
     except Exception as e:
+        logging.warning("Unable to refresh access token: %s", e)
         return False
 
 

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -260,7 +260,6 @@ class Printf(object):
 
     @staticmethod
     def err(string):
-        global print_mutex
         print_mutex.acquire()
         print(aigpy.cmd.red(LANG.select.PRINT_ERR + " ") + string)
         # logging.error(string)
@@ -268,14 +267,12 @@ class Printf(object):
 
     @staticmethod
     def info(string):
-        global print_mutex
         print_mutex.acquire()
         print(aigpy.cmd.blue(LANG.select.PRINT_INFO + " ") + string)
         print_mutex.release()
 
     @staticmethod
     def success(string):
-        global print_mutex
         print_mutex.acquire()
         print(aigpy.cmd.green(LANG.select.PRINT_SUCCESS + " ") + string)
         print_mutex.release()

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -259,6 +259,7 @@ class TidalAPI(object):
         params['countryCode'] = self.key.countryCode
         errmsg = "Get operation err!"
         respond = None
+        lastError = None
         refreshedToken = False
         url = urlpre + path
         playbackRequest = self.__isPlaybackPath__(path)
@@ -317,15 +318,19 @@ class TidalAPI(object):
             except TidalApiError as e:
                 if self.__isNonRetryableTidalApiError__(e, playbackRequest) or index >= maxAttempts - 1:
                     raise e
+                lastError = e
             except Exception as e:
+                lastError = e
                 if index >= maxAttempts - 1 and respond is not None:
                     errmsg += respond.text
 
         if respond is not None and self.__isAssetNotReady__(respond):
             body = self.__responseBody__(respond)
             message = body.get('userMessage') or 'Asset is not ready for playback'
-            raise Exception(f"{errmsg}{message}")
-        raise Exception(errmsg)
+            raise Exception(f"{errmsg}{message}") from lastError
+        if lastError is not None and aigpy.string.isNull(errmsg.replace("Get operation err!", "")):
+            raise Exception(f"{errmsg} {lastError}") from lastError
+        raise Exception(errmsg) from lastError
 
     def __getPlaybackData__(self, item_id, params, media='tracks'):
         params = dict(params or {})


### PR DESCRIPTION
## Summary
Addresses three code-quality findings (surfaced by `pyflakes`; not caught by current CI, which only runs compile + unittest).

### 1. Error masking in the API retry loop (`tidal.py`) — main fix
`__getOnce__` caught exceptions in its retry loop but discarded the captured exception, so failures collapsed into a vague (often empty) `Get operation err!`. Now the underlying exception is retained and chained into the final `raise ... from lastError`, and its message is included when no other detail is available. This makes download failures actually diagnosable (the kind of "no useful error" symptom seen in user reports).

### 2. Silent token-refresh failure (`events.py`)
The access-token refresh path swallowed its exception and returned `False` with no trace. Now logs `logging.warning("Unable to refresh access token: %s", e)` before returning, matching the package's existing logging convention.

### 3. Dead `global` statements (`printf.py`)
Removed three `global print_mutex` declarations that are read-only (never assigned), so they were no-ops.

## Testing
- `python -m compileall -q tidal_dl` — clean
- `python -m unittest discover -s tests` — **107 passed**
- `pyflakes tidal_dl` — the three findings above resolved

No behavior change beyond improved error messages/logging.