### PR TITLE
Added {ArtistID} as a variable for album filepaths

### DIFF
--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -29,8 +29,8 @@ def _playback_params(audioquality, prefetch=False):
 
 
 class CliAuthPathRegressionTests(unittest.TestCase):
-    def _artist(self, name="Artist"):
-        return SimpleNamespace(name=name)
+    def _artist(self, name="Artist", id=123):
+        return SimpleNamespace(name=name, id=id)
 
     def _album(self):
         artist = self._artist()

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -77,6 +77,7 @@ def __hasStreamIdentifierToken__(pathFormat: str):
 
 
 def getAlbumPath(album):
+    artistID = __fixPath__(TIDAL_API.getArtistsID(album.artists))
     artistName = __fixPath__(TIDAL_API.getArtistsName(album.artists))
     albumArtistName = __fixPath__(album.artist.name) if album.artist is not None else ""
 
@@ -95,6 +96,7 @@ def getAlbumPath(album):
     retpath = SETTINGS.albumFolderFormat
     if retpath is None or len(retpath) <= 0:
         retpath = SETTINGS.getDefaultPathFormat(Type.Album)
+    retpath = retpath.replace(R"{ArtistID}", artistID)
     retpath = retpath.replace(R"{ArtistName}", artistName)
     retpath = retpath.replace(R"{AlbumArtistName}", albumArtistName)
     retpath = retpath.replace(R"{Flag}", flag)

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -1088,6 +1088,10 @@ class TidalAPI(object):
         except requests.RequestException:
             return ''
 
+    def getArtistsID(self, artists=[]):
+        array = list(str(item.id) for item in artists)
+        return ", ".join(array)
+
     def getArtistsName(self, artists=[]):
         array = list(item.name for item in artists)
         return ", ".join(array)


### PR DESCRIPTION
To aid disambiguation between artists and enable reverse lookups I've added ArtistID as a variable for album file paths.

Primary changes are to tidal_dl/tidal.py and tidal_dl/paths.py.

I've also updated tests/tests_regressions.py to prevent the above changes from causing failures in the tests.