### PR TITLE
Feature/albumartistid token in album filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ tidekeeper -l "https://tidal.com/browse/track/70973230"
 tidekeeper --video-only -l "https://tidal.com/browse/artist/123456"
 ```
 
-Dolby Atmos downloads are opt-in with `tidekeeper -q Atmos`. Custom filename
-formats support tokens including `{ArtistName}`, `{ArtistID}`, `{StreamQuality}`,
-and `{Codec}`.
+Dolby Atmos downloads are opt-in with `tidekeeper -q Atmos`.
 
 Failed downloads are saved to `failed-tracks.txt` in the download folder and can
 be retried with:
@@ -54,6 +52,41 @@ be retried with:
 ```bash
 tidekeeper -l "/path/to/downloads/failed-tracks.txt"
 ```
+## Customizability
+Custom filename formats are supported:
+| Tokens  | Description  | Album | Track | Video | Playlist |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| {ArtistID}  | Comma seperated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {ArtistName}  | Comma seperated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {ArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {ArtistsName}  | Comma seperated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {AlbumArtistID}  | Primary artist's ID for that media | :white_check_mark:  | :x:  | :x:  | :x: |
+| {AlbumArtistName}  | Primary artist's name for that media | :white_check_mark:  | :x:  | :x:  | :x: |
+| {Flag}  | TBC | :white_check_mark:  | :x:  | :x:  | :x: |
+| {AlbumID}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {AlbumYear}  |  | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |
+| {AlbumTitle}  |  | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |
+| {AudioQuality}  | TBC | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |
+| {DurationSeconds}  |  | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |
+| {Duration}  | TBC | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |
+| {NumberOfTracks}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {NumberOfVideos}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {NumberOfVolumes}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {ReleaseDate}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {RecordType}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {TrackID}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {TrackNumber}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {TrackTitle}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {ExplicitFlag}  |  | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {TrackTitle}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {StreamQuality}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {Codec}  |  | :x:  | :white_check_mark:  | :x:  | :x: |
+| {VideoID}  |  | :x:  | :x:  | :white_check_mark:  | :x: |
+| {VideoNumber}  |  | :x:  | :x:  | :white_check_mark:  | :x: |
+| {VideoTitle}  |  | :x:  | :x:  | :white_check_mark:  | :x: |
+| {VideoYear}  |  | :x:  | :x:  | :white_check_mark:  | :x: |
+| {PlaylistUUID}  |  | :x:  | :x:  | :x:  | :white_check_mark: |
+| {PlaylistName}  |  | :x:  | :x:  | :x:  | :white_check_mark: |
 
 ## Desktop GUI
 

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -172,6 +172,13 @@ class CliAuthPathRegressionTests(unittest.TestCase):
             for key, value in old_values.items():
                 setattr(paths.SETTINGS, key, value)
 
+    def test_album_path_replaces_album_artist_ids_for_singular_artist(self):
+        album = self._album()
+        album.artist = self._artist("Artist One", 123)
+
+        with mock.patch.object(paths.SETTINGS, "albumFolderFormat", "{AlbumArtistID}/{AlbumTitle}"):
+            self.assertTrue(paths.getAlbumPath(album).endswith("123/Album"))
+
     def test_album_path_replaces_artist_ids_for_multiple_artists(self):
         album = self._album()
         album.artists = [self._artist("Artist One", 123), self._artist("Artist Two", 456)]

--- a/TIDALDL-PY/tidal_dl/model.py
+++ b/TIDALDL-PY/tidal_dl/model.py
@@ -62,7 +62,7 @@ class Album(aigpy.model.ModelBase):
         self.audioQuality = None
         self.audioModes = None
         self.artist = Artist()
-        self.artists = Artist()
+        self.artists = []
 
 
 class Playlist(aigpy.model.ModelBase):

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -79,6 +79,7 @@ def __hasStreamIdentifierToken__(pathFormat: str):
 def getAlbumPath(album):
     artistID = __fixPath__(TIDAL_API.getArtistsID(album.artists))
     artistName = __fixPath__(TIDAL_API.getArtistsName(album.artists))
+    albumArtistID = __fixPath__(str(album.artist.id))if album.artist is not None else "0"
     albumArtistName = __fixPath__(album.artist.name) if album.artist is not None else ""
 
     # album folder pre: [ME]
@@ -98,6 +99,7 @@ def getAlbumPath(album):
         retpath = SETTINGS.getDefaultPathFormat(Type.Album)
     retpath = retpath.replace(R"{ArtistID}", artistID)
     retpath = retpath.replace(R"{ArtistName}", artistName)
+    retpath = retpath.replace(R"{AlbumArtistID}", albumArtistID)
     retpath = retpath.replace(R"{AlbumArtistName}", albumArtistName)
     retpath = retpath.replace(R"{Flag}", flag)
     retpath = retpath.replace(R"{AlbumID}", str(album.id))


### PR DESCRIPTION
## Summary

In line with my previous pull request to add the token {ArtistID} I've also added {AlbumArtistID} to aid reverse-lookups.

It may also be worth investigating to see if getAlbumPath() can be  refactored to make it consistent with getTrackPath() and getVideoPath() (i.e: by changing {ArtistID} and {ArtistName} to {ArtistsID} and {ArtistsName} respectively, {AlbumArtistID} and {AlbumArtistName} to {ArtistID} and {ArtistName} respectively). This would make the token arrangements a bit easier to read with the downside of breaking existing configurations.

## Testing

All unit tests have been run but some errors did occur (that I believe are unreleated):
- ERR] DL Track 'Track' failed: Track is not ready for streaming yet. Try again later. (hint: retry later, raise the request interval in settings, or try a lower quality)
- [ERR] DL Track 'Track' failed: HTTP 429 (hint: raise the request interval in settings and retry)

Not sure which test(s) are causing these failures or why they're failing. I have quality set to 'max' with priority 'High, Lossless, Low' and request delay set to 60s'. 

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [X] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
