### PR TITLE
Added --configPathOverride as a CLI argument

### DIFF
--- a/TIDALDL-PY/tests/test_cli_ui.py
+++ b/TIDALDL-PY/tests/test_cli_ui.py
@@ -7,9 +7,13 @@ from unittest import mock
 import tidal_dl
 from tidal_dl import printf
 from tidal_dl.printf import Printf
+from tidal_dl.paths import PATHS
 
 
 class CliUiTests(unittest.TestCase):
+    def setUp(self):
+        PATHS.homePathOverride = None
+
     def test_compact_help_uses_one_option_per_line(self):
         output = io.StringIO()
 
@@ -113,6 +117,39 @@ class CliUiTests(unittest.TestCase):
                 tidal_dl.mainCommand()
 
         start.assert_called_once_with("artist-id", True)
+
+    def test_default_config_path(self):
+        assert(PATHS.__getHomePath__() == PATHS.__getDefaultHomePath__())
+
+    def test_config_path_override_overrides_paths(self):
+        with mock.patch("sys.argv", ["tidekeeper", "-c", "/home/user/tidekeeper/config"]):
+            with mock.patch("tidal_dl.__init__.os.path.isdir") as mock_isdir:
+                mock_isdir.return_value = True
+                tidal_dl.preMainCommand()
+        assert(PATHS.__getHomePath__() == "/home/user/tidekeeper/config")
+
+    def test_config_path_requires_existing_directory(self):
+        with mock.patch("sys.argv", ["tidekeeper", "-c", "/magic/config"]):
+            with self.assertRaises(ValueError):
+                tidal_dl.preMainCommand()
+
+    def test_sys_argvs_prevent_entering_while_loop(self):
+        with mock.patch("sys.argv", ["tidekeeper", "--paths"]):
+            with mock.patch("tidal_dl.__init__.Printf.choices") as mock_choices:
+                mock_choices.side_effect = KeyboardInterrupt
+                tidal_dl.main()
+        mock_choices.assert_not_called()
+
+    def test_sys_argvs_enable_entering_while_loop(self):
+        with mock.patch("sys.argv", ["tidekeeper", "-c", "/home/user/tidekeeper/config"]):
+            with mock.patch("tidal_dl.__init__.os.path.isdir") as mock_isdir:
+                mock_isdir.return_value = True
+                with mock.patch("tidal_dl.loginByWeb") as loginByWeb:
+                    with mock.patch("tidal_dl.__init__.Printf.choices") as mock_choices:
+                        mock_choices.side_effect = KeyboardInterrupt
+                        with self.assertRaises(KeyboardInterrupt):
+                            tidal_dl.main()
+        mock_choices.assert_called()
 
 
 if __name__ == "__main__":

--- a/TIDALDL-PY/tests/test_cli_ui.py
+++ b/TIDALDL-PY/tests/test_cli_ui.py
@@ -123,7 +123,7 @@ class CliUiTests(unittest.TestCase):
 
     def test_config_path_override_overrides_paths(self):
         with mock.patch("sys.argv", ["tidekeeper", "-c", "/home/user/tidekeeper/config"]):
-            with mock.patch("tidal_dl.__init__.os.path.isdir") as mock_isdir:
+            with mock.patch("tidal_dl.os.path.isdir") as mock_isdir:
                 mock_isdir.return_value = True
                 tidal_dl.preMainCommand()
         assert(PATHS.__getHomePath__() == "/home/user/tidekeeper/config")
@@ -135,14 +135,14 @@ class CliUiTests(unittest.TestCase):
 
     def test_sys_argvs_prevent_entering_while_loop(self):
         with mock.patch("sys.argv", ["tidekeeper", "--paths"]):
-            with mock.patch("tidal_dl.__init__.Printf.choices") as mock_choices:
+            with mock.patch("tidal_dl.Printf.choices") as mock_choices:
                 mock_choices.side_effect = KeyboardInterrupt
                 tidal_dl.main()
         mock_choices.assert_not_called()
 
     def test_sys_argvs_enable_entering_while_loop(self):
         with mock.patch("sys.argv", ["tidekeeper", "-c", "/home/user/tidekeeper/config"]):
-            with mock.patch("tidal_dl.__init__.os.path.isdir") as mock_isdir:
+            with mock.patch("tidal_dl.os.path.isdir") as mock_isdir:
                 mock_isdir.return_value = True
                 with mock.patch("tidal_dl.loginByWeb") as loginByWeb:
                     with mock.patch("tidal_dl.__init__.Printf.choices") as mock_choices:

--- a/TIDALDL-PY/tests/test_cli_ui.py
+++ b/TIDALDL-PY/tests/test_cli_ui.py
@@ -145,7 +145,7 @@ class CliUiTests(unittest.TestCase):
             with mock.patch("tidal_dl.os.path.isdir") as mock_isdir:
                 mock_isdir.return_value = True
                 with mock.patch("tidal_dl.loginByWeb") as loginByWeb:
-                    with mock.patch("tidal_dl.__init__.Printf.choices") as mock_choices:
+                    with mock.patch("tidal_dl.Printf.choices") as mock_choices:
                         mock_choices.side_effect = KeyboardInterrupt
                         with self.assertRaises(KeyboardInterrupt):
                             tidal_dl.main()

--- a/TIDALDL-PY/tests/test_paths.py
+++ b/TIDALDL-PY/tests/test_paths.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 from tidal_dl.model import StreamUrl
-from tidal_dl.paths import __getExtension__, getConfigDirectory, getPathSummary, openPath
+from tidal_dl.paths import __getExtension__, PATHS, openPath
 
 
 class PathTests(unittest.TestCase):
@@ -45,7 +45,7 @@ class PathTests(unittest.TestCase):
         self.assertEqual(__getExtension__(stream), ".m4a")
 
     def test_path_summary_contains_user_visible_locations(self):
-        labels = [label for label, value in getPathSummary()]
+        labels = [label for label, value in PATHS.getPathSummary()]
 
         self.assertIn("Download path", labels)
         self.assertIn("Config folder", labels)
@@ -54,7 +54,7 @@ class PathTests(unittest.TestCase):
         self.assertIn("Log file", labels)
 
     def test_config_directory_matches_settings_parent(self):
-        self.assertTrue(getConfigDirectory())
+        self.assertTrue(PATHS.getConfigDirectory())
 
     def test_open_path_creates_folder_and_launches_file_manager(self):
         with mock.patch("tidal_dl.paths.sys.platform", "linux"):

--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -9,13 +9,14 @@
 @Desc    :
 '''
 import sys
+import os
 import getopt
 import aigpy
 
 from .events import *
 from .settings import *
 from .diagnostics import runDoctor
-from .paths import getProfilePath, getTokenPath, openPath
+from .paths import PATHS, openPath
 from .printf import Printf
 from .updater import run_update
 
@@ -30,21 +31,35 @@ def startGui():
         return 1
     return gui_module.main()
 
+def preMainCommand():
+    preArgs = []
+    previousArg = ""
+    for arg in sys.argv[1:]:
+        if arg == "-c" or arg == "--configPathOverride" or previousArg == "-c" or previousArg == "--configPathOverride":
+            preArgs.append(arg)
+        previousArg = arg
+
+    opts, args = getopt.getopt(preArgs, "c:", ["configPathOverride="])
+    for opt, val in opts:
+        if opt in ('-c', '--configPathOverride'):
+            if os.path.isdir(val) == False:
+                raise ValueError("configPathOverride must be an existing directory")
+            PATHS.homePathOverride = val
 
 def mainCommand():
     try:
         opts, args = getopt.getopt(sys.argv[1:],
-                                   "hvgl:o:q:r:",
+                                   "hvgl:o:q:r:c:",
                                    [
                                        "help", "version", "gui", "doctor",
                                        "update", "update-gui",
                                        "paths", "open-output",
                                        "video-only", "videos-only",
-                                       "link=", "output=", "quality=", "quality-priority=", "resolution="
+                                       "link=", "output=", "quality=", "quality-priority=", "resolution=", "configPathOverride="
                                    ])
     except getopt.GetoptError as errmsg:
         Printf.err(vars(errmsg)['msg'] + ". Use 'tidekeeper -h' for usage.")
-        return
+        return True
 
     link = None
     showGui = False
@@ -58,10 +73,10 @@ def mainCommand():
     for opt, val in opts:
         if opt in ('-h', '--help'):
             Printf.usage()
-            return
+            return True
         if opt in ('-v', '--version'):
             Printf.logo()
-            return
+            return True
         if opt in ('-g', '--gui'):
             showGui = True
             continue
@@ -109,11 +124,11 @@ def mainCommand():
 
     if showDoctor:
         runDoctor()
-        return
+        return True
 
     if showPaths:
         Printf.paths()
-        return
+        return True
 
     if openOutput:
         try:
@@ -121,25 +136,26 @@ def mainCommand():
             Printf.success("Opened download folder: " + opened)
         except OSError as exc:
             Printf.err("Could not open download folder: " + str(exc))
-        return
+        return True
 
     if updateInstall:
         updateTidekeeper(updateGuiInstall)
-        return
+        return True
 
     if not aigpy.path.mkdirs(SETTINGS.downloadPath):
         Printf.err(LANG.select.MSG_PATH_ERR + SETTINGS.downloadPath)
-        return
+        return True
 
     if showGui:
         startGui()
-        return
+        return True
 
     if link is not None:
         if not loginByConfig() and not loginByWeb():
-            return
+            return True
         Printf.info(LANG.select.SETTING_DOWNLOAD_PATH + ':' + SETTINGS.downloadPath)
         start(link, videoOnly)
+    return False
 
 
 def normalizeChoice(choice):
@@ -196,16 +212,20 @@ def updateTidekeeper(include_gui=False):
 
 
 def main():
-    SETTINGS.read(getProfilePath())
-    TOKEN.read(getTokenPath())
+    if len(sys.argv) > 1:
+        preMainCommand()
+
+    SETTINGS.read(PATHS.getProfilePath())
+    TOKEN.read(PATHS.getTokenPath())
     if not apiKey.isItemValid(SETTINGS.apiKeyIndex):
         SETTINGS.apiKeyIndex = apiKey.getDefaultIndex()
         SETTINGS.save()
     TIDAL_API.apiKey = apiKey.getItem(SETTINGS.apiKeyIndex)
 
     if len(sys.argv) > 1:
-        mainCommand()
-        return
+        return_flag = mainCommand()
+        if return_flag:
+            return
 
     if not loginByConfig():
         loginByWeb()
@@ -247,8 +267,8 @@ def main():
 
 
 def test():
-    SETTINGS.read(getProfilePath())
-    TOKEN.read(getTokenPath())
+    SETTINGS.read(PATHS.getProfilePath())
+    TOKEN.read(PATHS.getTokenPath())
 
     if not loginByConfig():
         loginByWeb()
@@ -291,3 +311,6 @@ def test():
 if __name__ == '__main__':
     # test()
     main()
+
+
+

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -15,7 +15,7 @@ from ..diagnostics import runDoctor
 from ..enums import AudioQuality, Type, VideoQuality
 from ..events import loginByConfig, logout, start, start_type
 from ..lang.language import LANG
-from ..paths import getProfilePath, getTokenPath, openPath
+from ..paths import PATHS, openPath
 from ..printf import VERSION
 from ..settings import SETTINGS, TOKEN, syncPlaybackRateLimiter
 from ..tidal import TIDAL_API
@@ -142,8 +142,8 @@ def with_video_only(item: SearchItem, video_only: bool) -> SearchItem:
 
 class TidekeeperBackend:
     def initialize(self):
-        SETTINGS.read(getProfilePath())
-        TOKEN.read(getTokenPath())
+        SETTINGS.read(PATHS.getProfilePath())
+        TOKEN.read(PATHS.getTokenPath())
         if not apiKey.isItemValid(SETTINGS.apiKeyIndex):
             SETTINGS.apiKeyIndex = apiKey.getDefaultIndex()
             SETTINGS.save()

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -216,41 +216,6 @@ def getVideoPath(video, album=None, playlist=None):
     retpath = retpath.strip()
     return f"{base}/{retpath}{extension}"
 
-
-def __getHomePath__():
-    if "XDG_CONFIG_HOME" in os.environ:
-        return os.environ['XDG_CONFIG_HOME']
-    elif "HOME" in os.environ:
-        return os.environ['HOME']
-    elif "HOMEDRIVE" in os.environ and "HOMEPATH" in os.environ:
-        return os.environ['HOMEDRIVE'] + os.environ['HOMEPATH']
-    else:
-        return os.path.abspath("./")
-
-def getLogPath():
-    return __getHomePath__() + '/.tidal-dl.log'
-
-def getTokenPath():
-    return __getHomePath__() + '/.tidal-dl.token.json'
-
-def getProfilePath():
-    return __getHomePath__() + '/.tidal-dl.json'
-
-
-def getConfigDirectory():
-    return os.path.dirname(getProfilePath()) or os.path.abspath("./")
-
-
-def getPathSummary():
-    return [
-        ("Download path", SETTINGS.downloadPath),
-        ("Config folder", getConfigDirectory()),
-        ("Settings file", getProfilePath()),
-        ("Token file", getTokenPath()),
-        ("Log file", getLogPath()),
-    ]
-
-
 def openPath(path):
     target = os.path.abspath(os.path.expanduser(path or SETTINGS.downloadPath))
     if os.path.isfile(target):
@@ -264,3 +229,48 @@ def openPath(path):
     else:
         subprocess.Popen(["xdg-open", target])
     return target
+
+class Paths(aigpy.model.ModelBase):
+    homePathOverride = None
+
+    def __getHomePath__(self):
+        if self.homePathOverride == None:
+            return self.__getDefaultHomePath__()
+        else:
+            return self.homePathOverride
+
+    def __getDefaultHomePath__(self):
+        if "XDG_CONFIG_HOME" in os.environ:
+            return os.environ['XDG_CONFIG_HOME']
+        elif "HOME" in os.environ:
+            return os.environ['HOME']
+        elif "HOMEDRIVE" in os.environ and "HOMEPATH" in os.environ:
+            return os.environ['HOMEDRIVE'] + os.environ['HOMEPATH']
+        else:
+            return os.path.abspath("./")
+
+    def getLogPath(self):
+        return self.__getHomePath__() + '/.tidal-dl.log'
+
+    def getTokenPath(self):
+        return self.__getHomePath__() + '/.tidal-dl.token.json'
+
+    def getProfilePath(self):
+        return self.__getHomePath__() + '/.tidal-dl.json'
+
+
+    def getConfigDirectory(self):
+        return os.path.dirname(self.getProfilePath()) or os.path.abspath("./")
+
+
+    def getPathSummary(self):
+        return [
+            ("Download path", SETTINGS.downloadPath),
+            ("Config folder", self.getConfigDirectory()),
+            ("Settings file", self.getProfilePath()),
+            ("Token file", self.getTokenPath()),
+            ("Log file", self.getLogPath()),
+        ]
+
+# Singleton
+PATHS = Paths()

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -94,6 +94,7 @@ class Printf(object):
                 ("-q, --quality NAME", "Max (default), Atmos, Master, HiFi, High, Normal"),
                 ("--quality-priority LIST", "Fallback order, e.g. Max,HiFi,High,Normal"),
                 ("-r, --resolution NAME", "P1080, P720, P480, P360"),
+                ("-c, --configPathOverride", "Use non-default base path for config/tokens/logs")
             ]
             for option, description in rows:
                 print(option)
@@ -114,14 +115,15 @@ class Printf(object):
             ["-o, --output", "Set download path"],
             ["-q, --quality", "Set one audio quality: Max (default), Atmos, Master, HiFi, High, Normal"],
             ["--quality-priority", "Set fallback order, e.g. Max,HiFi,High,Normal"],
-            ["-r, --resolution", "Set video quality: P1080, P720, P480, P360"]
+            ["-r, --resolution", "Set video quality: P1080, P720, P480, P360"],
+            ["-c, --configPathOverride", "Use non-default base path for config/tokens/logs"]
         ])
         tb.set_style(prettytable.PLAIN_COLUMNS)
         print(tb)
 
     @staticmethod
     def paths():
-        tb = Printf.__gettable__(["PATH", "VALUE"], getPathSummary())
+        tb = Printf.__gettable__(["PATH", "VALUE"], PATHS.getPathSummary())
         tb.set_style(prettytable.PLAIN_COLUMNS)
         print(tb)
 
@@ -138,7 +140,7 @@ class Printf(object):
         data = SETTINGS
         tb = Printf.__gettable__([LANG.select.SETTING, LANG.select.VALUE], [
             #settings - path and format
-            [LANG.select.SETTING_PATH, getProfilePath()],
+            [LANG.select.SETTING_PATH, PATHS.getProfilePath()],
             [LANG.select.SETTING_DOWNLOAD_PATH, data.downloadPath],
             [LANG.select.SETTING_ALBUM_FOLDER_FORMAT, data.albumFolderFormat],
             [LANG.select.SETTING_PLAYLIST_FOLDER_FORMAT, data.playlistFolderFormat],


### PR DESCRIPTION
## Summary

Added ability to temporarily override the base 'home path' as a CLI argument (i.e: -c or --configPathOverride). 

Usecases include:
- Keepin/using multiple configurations 
- Containerised implementations directing tidekeeper to use a dedicated folder  

Primary changes:
- __init__.py: CLI arguments are now 'pre'-checked prior to Settings/Tokens being 'read' to enable detection of 'configPathOverride' argument. CLI arguments can individually set a return_flag to indicate the main while loop shouldn't be entered.
- paths.py: 'home path' related functions have been moved to a new singleton that can alter the 'home path'

Secondary changes:
- tests: tests have been added to ensure proposed functionality works and existing functionality is not broken
- Modules that use 'home path' related functions have been edited to point to the new PATHS singleton. 

## Testing

All unit tests: no failures

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [X] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
