### PR TITLE
Bugfix: link argument now correctly prevents entering main loop

### DIFF
--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -155,6 +155,7 @@ def mainCommand():
             return True
         Printf.info(LANG.select.SETTING_DOWNLOAD_PATH + ':' + SETTINGS.downloadPath)
         start(link, videoOnly)
+        return True
     return False
 
 


### PR DESCRIPTION
## Summary

Recent changes to __init__.py to support the --configPathOverride argument did not properly handle the -l argument.

Proposed change reverts the -l argument's behaviour such that it prevents the program from entering the main loop. 

## Testing

All unit tests. 1 failure observed that I believe is unrelated to this PR:

Fail: test_openapi_rate_limit_penalizes_shared_limiter (test_regressions.CliAuthPathRegressionTests.test_openapi_rate_limit_penalizes_shared_limiter)

Traceback (most recent call last):
  File "tidekeeper/TIDALDL-PY/tests/test_regressions.py", line 472, in test_openapi_rate_limit_penalizes_shared_limiter
    limiter.penalize.assert_called_once_with(17.0)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.14/unittest/mock.py", line 998, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/unittest/mock.py", line 986, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: mock(17.0)
  Actual: mock(60.0)

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [X] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
