### PR TITLE
Bugfix: dictToModel overrided to handle List[Model] attributes

### DIFF
--- a/TIDALDL-PY/tidal_dl/aigpy_overrides.py
+++ b/TIDALDL-PY/tidal_dl/aigpy_overrides.py
@@ -1,0 +1,36 @@
+from typing import get_args, get_origin, List
+from aigpy.dictHelper import DictTool
+from aigpy.modelHelper import __isDictList__, __isDict__
+
+# Direct replacement for aigpy.model.dictToModel. Performs additional checks compared to the upstream implementation to handle List[Model] attributes.
+def dictToModel(indict, model):
+    if indict is None or model is None:
+        return None
+    ret = model
+    maps = DictTool(indict)
+
+    members = [attr for attr in dir(ret) if not callable(getattr(model, attr)) and not attr.startswith("_")]
+
+    for key in members:
+        if key.lower() not in maps:
+            if __isObject__(getattr(ret, key)):
+                setattr(ret, key, None)
+            continue
+
+        lvalue = maps[key.lower()]
+        if __isDictList__(lvalue):
+            current_value = getattr(ret, key)
+            annotation = getattr(ret.__class__, "__annotations__", {}).get(key)
+            if annotation and get_origin(annotation) in (list, List):
+                item_type = get_args(annotation)[0]
+                value = [dictToModel(item, item_type()) for item in lvalue]
+            else:
+                value = dictListToModelList(lvalue, getattr(ret, key))
+
+        elif __isDict__(lvalue):
+            value = dictToModel(lvalue, getattr(ret, key))
+        else:
+            value = lvalue
+
+        setattr(ret, key, value)
+    return ret

--- a/TIDALDL-PY/tidal_dl/model.py
+++ b/TIDALDL-PY/tidal_dl/model.py
@@ -8,6 +8,7 @@
 @Contact :   yaronhuang@foxmail.com
 @Desc    :
 '''
+from typing import List
 import aigpy
 
 class StreamUrl(aigpy.model.ModelBase):
@@ -46,6 +47,8 @@ class Artist(aigpy.model.ModelBase):
 
 
 class Album(aigpy.model.ModelBase):
+    artists: List[Artist]
+
     def __init__(self) -> None:
         super().__init__()
         self.id = None

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -22,6 +22,7 @@ from urllib.parse import unquote, urlparse
 
 import requests
 
+from . import aigpy_overrides
 from .model import *
 from .settings import *
 
@@ -547,7 +548,7 @@ class TidalAPI(object):
         return
 
     def getAlbum(self, id) -> Album:
-        return aigpy.model.dictToModel(self.__get__('albums/' + str(id)), Album())
+        return aigpy_overrides.dictToModel(self.__get__('albums/' + str(id)), Album())
 
     def getPlaylist(self, id) -> Playlist:
         return aigpy.model.dictToModel(self.__get__('playlists/' + str(id)), Playlist())


### PR DESCRIPTION
## Summary

Proposed (interim) solution to [BUG Artists returns empty lists #38](https://github.com/OpenNerdz/tidekeeper/issues/38).

Provides an optional override for aigpy.model.dictToModel to handle List[Model] attributes in aigpy.models. The override expands on the "if __isDictList__(lvalue)" check to see if meaningful information can be extracted from an annotation for a given list attribute. If no annotation is provided it defaults to the upstream implementation.

Override and changes are only applied to the album model - although if desired this could be expanded to the other models.

## Testing

All unit tests. 1 failure observed that I believe is unrelated to this PR:

FAIL: test_openapi_rate_limit_penalizes_shared_limiter (test_regressions.CliAuthPathRegressionTests.test_openapi_rate_limit_penalizes_shared_limiter)

Traceback (most recent call last):
  File "/home/bluenexus6674/Downloads/TLook/Tidekeeper/tidekeeper/TIDALDL-PY/tests/test_regressions.py", line 472, in test_openapi_rate_limit_penalizes_shared_limiter
    limiter.penalize.assert_called_once_with(17.0)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.14/unittest/mock.py", line 998, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/unittest/mock.py", line 986, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: mock(17.0)
  Actual: mock(60.0)

FAILED (failures=1)

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [X] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
