### PR TITLE
Fix Atmos catalog selection for search and downloads (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Documented and enabled first-party PyPI installs (`pip install tidekeeper`).
 - `tidekeeper --update` and the one-line installer now install from PyPI by default.
+- Improved Dolby Atmos catalog selection (#44):
+  - Search quality labels show `Dolby Atmos` when `audioModes` includes `DOLBY_ATMOS` (Atmos releases often report `LOW`).
+  - Track models retain `audioModes` from TIDAL search/catalog payloads.
+  - When download quality is Atmos, stereo album/track picks auto-resolve to the matching Atmos catalog twin when available.
+  - Album details print max quality, audio modes, and flags.
 - Hardened track CDN downloads for reliability and stability:
   - Mismatched HTTP Range responses re-fetch fully instead of writing a truncated body.
   - Multi-segment DASH/HLS parts use per-segment resume (sequential and parallel).

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ tidekeeper -l "https://tidal.com/browse/track/70973230"
 tidekeeper --video-only -l "https://tidal.com/browse/artist/123456"
 ```
 
-Dolby Atmos downloads are opt-in with `tidekeeper -q Atmos`.
+Dolby Atmos downloads are opt-in with `tidekeeper -q Atmos` (or GUI audio quality
+**Atmos**). TIDAL keeps Atmos mixes on separate catalog IDs that often report
+quality `LOW` with an Atmos flag — search now labels those rows clearly, and
+when Atmos quality is selected Tidekeeper will switch a stereo album/track pick
+to the matching Atmos catalog release when one exists.
 
 Failed downloads are saved to `failed-tracks.txt` in the download folder and can
 be retried with:

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -905,6 +905,137 @@ class CliAuthPathRegressionTests(unittest.TestCase):
         album = SimpleNamespace(audioQuality="LOW", audioModes=None, explicit=False)
         self.assertEqual(TidalAPI().getFlag(album, Type.Album), "")
 
+    def test_track_flag_detects_atmos_audio_modes(self):
+        track = SimpleNamespace(audioQuality="LOW", audioModes=["DOLBY_ATMOS"], explicit=False)
+        self.assertEqual(TidalAPI().getFlag(track, Type.Track, short=False), "Dolby Atmos")
+        self.assertEqual(TidalAPI().getFlag(track, Type.Track, short=True), "A")
+
+    def test_search_quality_label_includes_atmos_mode(self):
+        from tidal_dl.gui_app.backend import _item_quality
+
+        album = SimpleNamespace(audioQuality="LOW", audioModes=["DOLBY_ATMOS"], explicit=True)
+        self.assertEqual(_item_quality(album, Type.Album), "LOW · Dolby Atmos · Explicit")
+
+        stereo = SimpleNamespace(audioQuality="LOSSLESS", audioModes=["STEREO"], explicit=False)
+        self.assertEqual(_item_quality(stereo, Type.Album), "LOSSLESS")
+
+    def test_find_atmos_album_variant_prefers_matching_title(self):
+        api = TidalAPI()
+        stereo = SimpleNamespace(
+            id=100,
+            title="Happier Than Ever",
+            audioModes=["STEREO"],
+            audioQuality="LOSSLESS",
+            explicit=True,
+            numberOfTracks=16,
+            artist=SimpleNamespace(id=7, name="Billie"),
+            artists=[SimpleNamespace(id=7, name="Billie")],
+        )
+        atmos = SimpleNamespace(
+            id=200,
+            title="Happier Than Ever",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            explicit=True,
+            numberOfTracks=16,
+            artist=SimpleNamespace(id=7, name="Billie"),
+            artists=[SimpleNamespace(id=7, name="Billie")],
+        )
+        other = SimpleNamespace(
+            id=300,
+            title="Other Album",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            explicit=False,
+            numberOfTracks=10,
+            artist=SimpleNamespace(id=7, name="Billie"),
+            artists=[SimpleNamespace(id=7, name="Billie")],
+        )
+        with mock.patch.object(api, "getArtistAlbums", return_value=[stereo, other, atmos]):
+            found = api.findAtmosAlbumVariant(stereo)
+        self.assertIs(found, atmos)
+
+    def test_find_atmos_track_variant_matches_title_and_number(self):
+        api = TidalAPI()
+        stereo_track = SimpleNamespace(
+            id=11,
+            title="Getting Older",
+            audioModes=["STEREO"],
+            isrc="USUG121",
+            trackNumber=1,
+            volumeNumber=1,
+            album=SimpleNamespace(id=100),
+        )
+        stereo_album = SimpleNamespace(
+            id=100,
+            title="Happier Than Ever",
+            audioModes=["STEREO"],
+            audioQuality="LOSSLESS",
+            explicit=True,
+            numberOfTracks=16,
+            artist=SimpleNamespace(id=7, name="Billie"),
+            artists=[SimpleNamespace(id=7, name="Billie")],
+        )
+        atmos_album = SimpleNamespace(
+            id=200,
+            title="Happier Than Ever",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            explicit=True,
+            numberOfTracks=16,
+            artist=SimpleNamespace(id=7, name="Billie"),
+            artists=[SimpleNamespace(id=7, name="Billie")],
+        )
+        atmos_track = SimpleNamespace(
+            id=22,
+            title="Getting Older",
+            audioModes=["DOLBY_ATMOS"],
+            isrc="USUG121",
+            trackNumber=1,
+            volumeNumber=1,
+            album=atmos_album,
+        )
+        with mock.patch.object(api, "getAlbum", return_value=stereo_album), \
+             mock.patch.object(api, "findAtmosAlbumVariant", return_value=atmos_album), \
+             mock.patch.object(api, "getItems", return_value=([atmos_track], [])):
+            found = api.findAtmosTrackVariant(stereo_track)
+        self.assertIs(found, atmos_track)
+
+    def test_album_download_switches_to_atmos_catalog_when_requested(self):
+        stereo = SimpleNamespace(
+            id=100,
+            title="Album",
+            audioModes=["STEREO"],
+            audioQuality="LOSSLESS",
+            cover=None,
+        )
+        atmos = SimpleNamespace(
+            id=200,
+            title="Album",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            cover=None,
+        )
+        old_quality = events.SETTINGS.audioQuality
+        old_priority = events.SETTINGS.audioQualityPriority
+        try:
+            events.SETTINGS.audioQuality = AudioQuality.Atmos
+            events.SETTINGS.audioQualityPriority = []
+            with mock.patch.object(events.TIDAL_API, "findAtmosAlbumVariant", return_value=atmos) as resolve, \
+                 mock.patch.object(events.Printf, "album"), \
+                 mock.patch.object(events.Printf, "info"), \
+                 mock.patch.object(events.TIDAL_API, "getItems", return_value=([], [])) as get_items, \
+                 mock.patch.object(events, "downloadTracks", return_value=True), \
+                 mock.patch.object(events, "downloadVideos", return_value=True), \
+                 mock.patch.object(events, "downloadAlbumInfo"), \
+                 mock.patch.object(events, "downloadCover"):
+                self.assertTrue(events.start_album(stereo))
+            resolve.assert_called_once_with(stereo)
+            get_items.assert_called_once_with(200, Type.Album)
+        finally:
+            events.SETTINGS.audioQuality = old_quality
+            events.SETTINGS.audioQualityPriority = old_priority
+
     def test_get_cover_data_uses_timeout(self):
         api = TidalAPI()
         response = SimpleNamespace(content=b"cover")

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -20,7 +20,44 @@ START DOWNLOAD
 '''
 
 
+def __wantsAtmosDownload__() -> bool:
+    return any(quality == AudioQuality.Atmos for quality in SETTINGS.getDownloadAudioQualityPriority())
+
+
+def __resolveAlbumForDownload__(obj: Album) -> Album:
+    """Prefer the Atmos catalog twin when Atmos quality is requested."""
+    if obj is None or not __wantsAtmosDownload__():
+        return obj
+    if TIDAL_API.__hasAtmosMode__(obj):
+        return obj
+    atmos = TIDAL_API.findAtmosAlbumVariant(obj)
+    if atmos is None or str(getattr(atmos, "id", "")) == str(getattr(obj, "id", "")):
+        return obj
+    Printf.info(
+        f"Using Dolby Atmos catalog release {atmos.id} "
+        f"(stereo search result was {obj.id})."
+    )
+    return atmos
+
+
+def __resolveTrackForDownload__(obj: Track) -> Track:
+    """Prefer the Atmos catalog twin when Atmos quality is requested."""
+    if obj is None or not __wantsAtmosDownload__():
+        return obj
+    if TIDAL_API.__hasAtmosMode__(obj):
+        return obj
+    atmos = TIDAL_API.findAtmosTrackVariant(obj)
+    if atmos is None or str(getattr(atmos, "id", "")) == str(getattr(obj, "id", "")):
+        return obj
+    Printf.info(
+        f"Using Dolby Atmos track {atmos.id} "
+        f"(stereo search result was {obj.id})."
+    )
+    return atmos
+
+
 def start_album(obj: Album, videoOnly=False):
+    obj = __resolveAlbumForDownload__(obj)
     Printf.album(obj)
     tracks, videos = TIDAL_API.getItems(obj.id, Type.Album)
     success = True
@@ -36,6 +73,7 @@ def start_album(obj: Album, videoOnly=False):
 
 
 def start_track(obj: Track):
+    obj = __resolveTrackForDownload__(obj)
     album = TIDAL_API.getAlbum(obj.album.id)
     if SETTINGS.saveCovers:
         downloadCover(album)

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -114,8 +114,23 @@ def _item_title(item) -> str:
     return getattr(item, "title", None) or getattr(item, "name", None) or "Untitled"
 
 
-def _item_quality(item) -> str:
-    return getattr(item, "audioQuality", None) or getattr(item, "quality", None) or ""
+def _item_quality(item, kind: Type | None = None) -> str:
+    """Catalog quality plus Atmos/Master/Explicit flags when present.
+
+    Atmos releases often report audioQuality=LOW. Without the audioModes flag
+    they look worse than stereo LOSSLESS results even though they are the only
+    IDs that can download Dolby Atmos.
+    """
+    quality = getattr(item, "audioQuality", None) or getattr(item, "quality", None) or ""
+    flag = ""
+    if kind in (Type.Album, Type.Track, Type.Video):
+        try:
+            flag = TIDAL_API.getFlag(item, kind, short=False, separator=" · ")
+        except Exception:
+            flag = ""
+    if quality and flag:
+        return f"{quality} · {flag}"
+    return str(quality or flag or "")
 
 
 def _item_identifier(item, kind: Type) -> str:
@@ -129,7 +144,7 @@ def to_search_item(kind: Type, item) -> SearchItem:
         kind=kind,
         title=_item_title(item),
         artists=_artists_label(item),
-        quality=_item_quality(item),
+        quality=_item_quality(item, kind),
         identifier=_item_identifier(item, kind),
         duration=_duration_label(getattr(item, "duration", 0)),
         source=item,

--- a/TIDALDL-PY/tidal_dl/model.py
+++ b/TIDALDL-PY/tidal_dl/model.py
@@ -92,6 +92,8 @@ class Track(aigpy.model.ModelBase):
         self.isrc = None
         self.explicit = False
         self.audioQuality = None
+        # TIDAL search/catalog payloads include audioModes (e.g. STEREO / DOLBY_ATMOS).
+        self.audioModes = None
         self.copyRight = None
         self.artist = Artist()
         self.artists = Artist()

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -16,9 +16,11 @@ import shutil
 
 from . import apiKey as apiKey
 
+from .enums import Type
 from .model import *
 from .paths import *
 from .settings import *
+from .tidal import TIDAL_API
 from .environment import isTermux
 from .lang.language import *
 
@@ -292,6 +294,9 @@ class Printf(object):
 
     @staticmethod
     def album(data: Album):
+        modes = getattr(data, "audioModes", None) or []
+        modes_label = ", ".join(str(mode) for mode in modes) if modes else ""
+        flag = TIDAL_API.getFlag(data, Type.Album, short=False)
         tb = Printf.__gettable__([LANG.select.MODEL_ALBUM_PROPERTY, LANG.select.VALUE], [
             [LANG.select.MODEL_TITLE, data.title],
             ["ID", data.id],
@@ -300,6 +305,9 @@ class Printf(object):
             [LANG.select.MODEL_RELEASE_DATE, data.releaseDate],
             [LANG.select.MODEL_VERSION, data.version],
             [LANG.select.MODEL_EXPLICIT, data.explicit],
+            ["Max-Q", getattr(data, "audioQuality", None)],
+            ["Audio modes", modes_label or None],
+            ["Flags", flag or None],
         ])
         print(tb)
         logging.info("====album " + str(data.id) + "====\n" +

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -1174,6 +1174,10 @@ class TidalAPI(object):
             if getattr(item, 'name', None)
         )
 
+    def __hasAtmosMode__(self, data) -> bool:
+        modes = getattr(data, "audioModes", None) or []
+        return any(str(mode).upper() == "DOLBY_ATMOS" for mode in modes)
+
     def getFlag(self, data, type: Type, short=True, separator=" / "):
         master = False
         atmos = False
@@ -1181,7 +1185,8 @@ class TidalAPI(object):
         if type == Type.Album or type == Type.Track:
             if data.audioQuality == "HI_RES":
                 master = True
-            if type == Type.Album and "DOLBY_ATMOS" in (data.audioModes or []):
+            # Atmos catalog rows often report audioQuality=LOW; audioModes is the real signal.
+            if self.__hasAtmosMode__(data):
                 atmos = True
             if data.explicit is True:
                 explicit = True
@@ -1198,6 +1203,113 @@ class TidalAPI(object):
         if explicit:
             array.append("E" if short else "Explicit")
         return separator.join(array)
+
+    def __normalizeCatalogTitle__(self, title) -> str:
+        text = (title or "").strip().lower()
+        return " ".join(text.split())
+
+    def findAtmosAlbumVariant(self, album: Album):
+        """Return a Dolby Atmos catalog twin for a stereo album, or the album itself.
+
+        TIDAL keeps Atmos mixes as separate album/track IDs. Search often ranks the
+        stereo LOSSLESS release first; the Atmos release usually has audioQuality=LOW
+        and audioModes containing DOLBY_ATMOS.
+        """
+        if album is None:
+            return None
+        if self.__hasAtmosMode__(album):
+            return album
+
+        artist_id = None
+        artist = getattr(album, "artist", None)
+        if artist is not None and getattr(artist, "id", None) is not None:
+            artist_id = artist.id
+        if artist_id is None:
+            for item in self.__artistList__(getattr(album, "artists", None)):
+                if getattr(item, "id", None) is not None:
+                    artist_id = item.id
+                    break
+        if artist_id is None:
+            return None
+
+        target_title = self.__normalizeCatalogTitle__(getattr(album, "title", None))
+        if not target_title:
+            return None
+
+        try:
+            candidates = self.getArtistAlbums(artist_id, includeEP=True) or []
+        except Exception as e:
+            logging.info("Unable to look up Atmos album variant for album %s: %s", getattr(album, "id", ""), e)
+            return None
+
+        matches = []
+        for candidate in candidates:
+            if not self.__hasAtmosMode__(candidate):
+                continue
+            if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) != target_title:
+                continue
+            matches.append(candidate)
+        if not matches:
+            return None
+
+        def score(candidate):
+            track_delta = abs(
+                int(getattr(candidate, "numberOfTracks", 0) or 0)
+                - int(getattr(album, "numberOfTracks", 0) or 0)
+            )
+            same_explicit = int(bool(getattr(candidate, "explicit", False)) != bool(getattr(album, "explicit", False)))
+            return (track_delta, same_explicit, str(getattr(candidate, "id", "")))
+
+        best = sorted(matches, key=score)[0]
+        if str(getattr(best, "id", "")) == str(getattr(album, "id", "")):
+            return album
+        return best
+
+    def findAtmosTrackVariant(self, track: Track):
+        """Return a Dolby Atmos catalog twin for a stereo track when available."""
+        if track is None:
+            return None
+        if self.__hasAtmosMode__(track):
+            return track
+
+        album_ref = getattr(track, "album", None)
+        album_id = getattr(album_ref, "id", None) if album_ref is not None else None
+        if album_id is None:
+            return None
+
+        try:
+            album = self.getAlbum(album_id)
+        except Exception as e:
+            logging.info("Unable to load album %s for Atmos track variant: %s", album_id, e)
+            return None
+
+        atmos_album = self.findAtmosAlbumVariant(album)
+        if atmos_album is None or str(getattr(atmos_album, "id", "")) == str(album_id):
+            return None
+
+        try:
+            atmos_tracks, _ = self.getItems(atmos_album.id, Type.Album)
+        except Exception as e:
+            logging.info("Unable to list Atmos album %s tracks: %s", getattr(atmos_album, "id", ""), e)
+            return None
+
+        target_title = self.__normalizeCatalogTitle__(getattr(track, "title", None))
+        target_isrc = (getattr(track, "isrc", None) or "").strip().upper()
+        target_number = getattr(track, "trackNumber", None)
+        target_volume = getattr(track, "volumeNumber", None)
+
+        for candidate in atmos_tracks or []:
+            if target_isrc and (getattr(candidate, "isrc", None) or "").strip().upper() == target_isrc:
+                return candidate
+        for candidate in atmos_tracks or []:
+            if target_number is not None and getattr(candidate, "trackNumber", None) == target_number:
+                if target_volume is None or getattr(candidate, "volumeNumber", None) == target_volume:
+                    if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
+                        return candidate
+        for candidate in atmos_tracks or []:
+            if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
+                return candidate
+        return None
 
     def parseUrl(self, url):
         if "tidal.com" not in url:


### PR DESCRIPTION
## Summary
- Search quality labels now show **Dolby Atmos** when `audioModes` includes `DOLBY_ATMOS` (Atmos rows often report `LOW`).
- Track models keep `audioModes` from TIDAL payloads.
- When download quality is **Atmos**, stereo album/track picks auto-resolve to the matching Atmos catalog twin when available.
- Album details print max quality, audio modes, and flags.

## Why
Closes #44. TIDAL keeps Atmos mixes on separate catalog IDs. Users picking stereo LOSSLESS search hits with `-q Atmos` got FLAC fallbacks.

## Test plan
- [x] Unit tests for flags, quality labels, album/track variant resolution, download switch
- [x] Full suite: 159 tests OK
- [x] Live API: stereo Happier Than Ever → Atmos twin → `DOLBY_ATMOS` / `ec-3` stream