### PR TITLE
Complete Atmos catalog fix for search, playlists, and GUI (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - `tidekeeper --update` and the one-line installer now install from PyPI by default.
 - Improved Dolby Atmos catalog selection (#44):
   - Search quality labels show `Dolby Atmos` when `audioModes` includes `DOLBY_ATMOS` (Atmos releases often report `LOW`).
+  - Album search injects matching Atmos catalog twins when TIDAL only returns the stereo row.
   - Track models retain `audioModes` from TIDAL search/catalog payloads.
-  - When download quality is Atmos, stereo album/track picks auto-resolve to the matching Atmos catalog twin when available.
+  - When download quality is Atmos, stereo album/track/playlist/mix picks auto-resolve to the matching Atmos catalog twin.
+  - Artist downloads skip stereo albums when an Atmos twin is already in the list.
+  - GUI applies current Settings (including Atmos quality) before starting downloads.
   - Album details print max quality, audio modes, and flags.
 - Hardened track CDN downloads for reliability and stability:
   - Mismatched HTTP Range responses re-fetch fully instead of writing a truncated body.

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -1036,6 +1036,100 @@ class CliAuthPathRegressionTests(unittest.TestCase):
             events.SETTINGS.audioQuality = old_quality
             events.SETTINGS.audioQualityPriority = old_priority
 
+    def test_download_track_resolves_atmos_for_playlist_path(self):
+        stereo = SimpleNamespace(
+            id=11,
+            title="Track",
+            version=None,
+            audioModes=["STEREO"],
+            album=SimpleNamespace(id=100, title="Album"),
+            allowStreaming=True,
+            streamReady=True,
+            explicit=False,
+            audioQuality="LOSSLESS",
+        )
+        atmos = SimpleNamespace(
+            id=22,
+            title="Track",
+            version=None,
+            audioModes=["DOLBY_ATMOS"],
+            album=SimpleNamespace(id=200, title="Album"),
+            allowStreaming=True,
+            streamReady=True,
+            explicit=False,
+            audioQuality="LOW",
+        )
+        atmos_album = SimpleNamespace(id=200, title="Album", cover=None)
+        stream = self._stream()
+        stream.soundQuality = "DOLBY_ATMOS"
+        stream.codec = "ec-3"
+        stream.fallbackReason = None
+        old_quality = download.SETTINGS.audioQuality
+        old_priority = download.SETTINGS.audioQualityPriority
+        old_show = download.SETTINGS.showTrackInfo
+        try:
+            download.SETTINGS.audioQuality = AudioQuality.Atmos
+            download.SETTINGS.audioQualityPriority = []
+            download.SETTINGS.showTrackInfo = False
+            with mock.patch.object(download.TIDAL_API, "findAtmosTrackVariant", return_value=atmos) as resolve, \
+                 mock.patch.object(download.TIDAL_API, "getAlbum", return_value=atmos_album), \
+                 mock.patch.object(download, "__getTrackStream__", return_value=stream) as get_stream, \
+                 mock.patch.object(download, "getTrackPath", return_value="/tmp/track.m4a"), \
+                 mock.patch.object(download, "__skipPath__", return_value="/tmp/track.m4a"), \
+                 mock.patch.object(download, "__saveLyricsForTrack__", return_value=None), \
+                 mock.patch.object(download.Printf, "success"), \
+                 mock.patch.object(download.Printf, "info"):
+                ok, err = download.downloadTrack(stereo, album=None, playlist=SimpleNamespace(uuid="p", title="Playlist"))
+            self.assertTrue(ok)
+            self.assertEqual(err, "")
+            resolve.assert_called_once_with(stereo)
+            get_stream.assert_called_once_with(22)
+        finally:
+            download.SETTINGS.audioQuality = old_quality
+            download.SETTINGS.audioQualityPriority = old_priority
+            download.SETTINGS.showTrackInfo = old_show
+
+    def test_prefer_atmos_search_albums_injects_missing_twin(self):
+        api = TidalAPI()
+        stereo = SimpleNamespace(
+            id=100,
+            title="Album",
+            audioModes=["STEREO"],
+            audioQuality="LOSSLESS",
+            explicit=False,
+            numberOfTracks=10,
+            artist=SimpleNamespace(id=1),
+            artists=[SimpleNamespace(id=1)],
+        )
+        atmos = SimpleNamespace(
+            id=200,
+            title="Album",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            explicit=False,
+            numberOfTracks=10,
+            artist=SimpleNamespace(id=1),
+            artists=[SimpleNamespace(id=1)],
+        )
+        with mock.patch.object(api, "findAtmosAlbumVariant", return_value=atmos):
+            enriched = api.preferAtmosSearchAlbums([stereo])
+        self.assertEqual([item.id for item in enriched], [100, 200])
+
+    def test_artist_album_list_skips_stereo_when_atmos_twin_present(self):
+        stereo = SimpleNamespace(id=100, title="Album", audioModes=["STEREO"])
+        atmos = SimpleNamespace(id=200, title="Album", audioModes=["DOLBY_ATMOS"])
+        other = SimpleNamespace(id=300, title="Other", audioModes=["STEREO"])
+        old_quality = events.SETTINGS.audioQuality
+        old_priority = events.SETTINGS.audioQualityPriority
+        try:
+            events.SETTINGS.audioQuality = AudioQuality.Atmos
+            events.SETTINGS.audioQualityPriority = []
+            preferred = events.__preferAtmosAlbums__([stereo, atmos, other])
+            self.assertEqual([item.id for item in preferred], [200, 300])
+        finally:
+            events.SETTINGS.audioQuality = old_quality
+            events.SETTINGS.audioQualityPriority = old_priority
+
     def test_get_cover_data_uses_timeout(self):
         api = TidalAPI()
         response = SimpleNamespace(content=b"cover")

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -1055,6 +1055,40 @@ def __getTrackStream__(track_id):
     return TIDAL_API.getStreamUrlByPriority(track_id, priority)
 
 
+def __wantsAtmosDownload__():
+    return any(quality == AudioQuality.Atmos for quality in SETTINGS.getDownloadAudioQualityPriority())
+
+
+def __resolveTrackForAtmosDownload__(track: Track, album=None):
+    """Swap stereo catalog IDs for Atmos twins when Atmos quality is requested.
+
+    Covers album, track, playlist, and mix paths — not only start_track().
+    """
+    if track is None or not __wantsAtmosDownload__():
+        return track, album
+    if TIDAL_API.__hasAtmosMode__(track):
+        return track, album
+
+    atmos = TIDAL_API.findAtmosTrackVariant(track)
+    if atmos is None or str(getattr(atmos, 'id', '')) == str(getattr(track, 'id', '')):
+        return track, album
+
+    Printf.info(
+        f"Using Dolby Atmos track {atmos.id} "
+        f"(stereo catalog id was {track.id})."
+    )
+
+    atmos_album = album
+    atmos_album_id = getattr(getattr(atmos, 'album', None), 'id', None)
+    album_id = getattr(album, 'id', None) if album is not None else None
+    if atmos_album_id is not None and str(atmos_album_id) != str(album_id or ''):
+        try:
+            atmos_album = TIDAL_API.getAlbum(atmos_album_id)
+        except Exception:
+            atmos_album = album
+    return atmos, atmos_album
+
+
 def __ensureTrackStreamable__(track):
     if getattr(track, 'allowStreaming', None) is False:
         raise Exception("Track is not available for streaming on this account.")
@@ -1075,6 +1109,8 @@ def downloadTrack(track: Track, album=None, playlist=None, userProgress=None, pa
     title = getattr(track, 'title', None) or str(getattr(track, 'id', 'unknown'))
     partPath = ''
     try:
+        track, album = __resolveTrackForAtmosDownload__(track, album)
+        title = getattr(track, 'title', None) or str(getattr(track, 'id', 'unknown'))
         __ensureTrackStreamable__(track)
         stream = __getTrackStream__(track.id)
         path = getTrackPath(track, stream, album, playlist)

--- a/TIDALDL-PY/tidal_dl/events.py
+++ b/TIDALDL-PY/tidal_dl/events.py
@@ -12,16 +12,13 @@
 import logging
 
 from .download import *
+from .download import __wantsAtmosDownload__  # import * skips underscore names
 
 '''
 =================================
 START DOWNLOAD
 =================================
 '''
-
-
-def __wantsAtmosDownload__() -> bool:
-    return any(quality == AudioQuality.Atmos for quality in SETTINGS.getDownloadAudioQualityPriority())
 
 
 def __resolveAlbumForDownload__(obj: Album) -> Album:
@@ -40,20 +37,27 @@ def __resolveAlbumForDownload__(obj: Album) -> Album:
     return atmos
 
 
-def __resolveTrackForDownload__(obj: Track) -> Track:
-    """Prefer the Atmos catalog twin when Atmos quality is requested."""
-    if obj is None or not __wantsAtmosDownload__():
-        return obj
-    if TIDAL_API.__hasAtmosMode__(obj):
-        return obj
-    atmos = TIDAL_API.findAtmosTrackVariant(obj)
-    if atmos is None or str(getattr(atmos, "id", "")) == str(getattr(obj, "id", "")):
-        return obj
-    Printf.info(
-        f"Using Dolby Atmos track {atmos.id} "
-        f"(stereo search result was {obj.id})."
-    )
-    return atmos
+def __preferAtmosAlbums__(albums):
+    """When Atmos is requested, skip stereo albums that already have an Atmos twin in the list."""
+    if not albums or not __wantsAtmosDownload__():
+        return albums
+
+    atmos_titles = {
+        TIDAL_API.__normalizeCatalogTitle__(getattr(album, "title", None))
+        for album in albums
+        if TIDAL_API.__hasAtmosMode__(album)
+    }
+    preferred = []
+    for album in albums:
+        title = TIDAL_API.__normalizeCatalogTitle__(getattr(album, "title", None))
+        if (
+            title
+            and title in atmos_titles
+            and not TIDAL_API.__hasAtmosMode__(album)
+        ):
+            continue
+        preferred.append(album)
+    return preferred
 
 
 def start_album(obj: Album, videoOnly=False):
@@ -73,10 +77,13 @@ def start_album(obj: Album, videoOnly=False):
 
 
 def start_track(obj: Track):
-    obj = __resolveTrackForDownload__(obj)
-    album = TIDAL_API.getAlbum(obj.album.id)
-    if SETTINGS.saveCovers:
-        downloadCover(album)
+    # downloadTrack resolves Atmos twins for album/track/playlist/mix paths.
+    album = None
+    album_id = getattr(getattr(obj, "album", None), "id", None)
+    if album_id is not None:
+        album = TIDAL_API.getAlbum(album_id)
+        if SETTINGS.saveCovers:
+            downloadCover(album)
     check, _ = downloadTrack(obj, album)
     return check
 
@@ -95,7 +102,7 @@ def start_artist(obj: Artist, videoOnly=False):
             return False
         return downloadVideos(videos, None)
 
-    albums = TIDAL_API.getArtistAlbums(obj.id, SETTINGS.includeEP)
+    albums = __preferAtmosAlbums__(TIDAL_API.getArtistAlbums(obj.id, SETTINGS.includeEP))
     Printf.artist(obj, len(albums))
     success = True
     for item in albums:

--- a/TIDALDL-PY/tidal_dl/gui_app/backend.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/backend.py
@@ -258,12 +258,15 @@ class TidekeeperBackend:
         if kind == Type.Null:
             items = []
             for result_kind in (Type.Artist, Type.Album, Type.Track, Type.Playlist, Type.Video):
-                items.extend(
-                    to_search_item(result_kind, item)
-                    for item in TIDAL_API.getSearchResultItems(result, result_kind)
-                )
+                raw_items = TIDAL_API.getSearchResultItems(result, result_kind)
+                if result_kind == Type.Album:
+                    raw_items = TIDAL_API.preferAtmosSearchAlbums(raw_items)
+                items.extend(to_search_item(result_kind, item) for item in raw_items)
             return items
-        return [to_search_item(kind, item) for item in TIDAL_API.getSearchResultItems(result, kind)]
+        raw_items = TIDAL_API.getSearchResultItems(result, kind)
+        if kind == Type.Album:
+            raw_items = TIDAL_API.preferAtmosSearchAlbums(raw_items)
+        return [to_search_item(kind, item) for item in raw_items]
 
     def artist_tracks(self, artist: SearchItem) -> List[SearchItem]:
         self._ensure_catalog_session()

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -859,6 +859,8 @@ class MainWindow(QMainWindow):
         if self.download_in_progress:
             self.queue_status.setText("A download is already running.")
             return
+        # Honor the Settings screen even if the user did not click Save first.
+        self.apply_settings_for_download()
         self.download_in_progress = True
         self._cancel_requested = False
         self.update_action_states()
@@ -1018,7 +1020,7 @@ class MainWindow(QMainWindow):
             if self.priority_preset.itemText(index).startswith("Custom saved: "):
                 self.priority_preset.removeItem(index)
 
-    def save_settings(self):
+    def collect_settings_values(self) -> dict:
         values = {
             "downloadPath": self.download_path.text().strip(),
             "audioQuality": self.audio_quality.currentData(),
@@ -1033,7 +1035,14 @@ class MainWindow(QMainWindow):
         }
         values.update({key: checkbox.isChecked() for key, checkbox in self.checks.items()})
         values["requestIntervalSeconds"] = float(self.request_interval.value())
-        self.backend.save_settings(values)
+        return values
+
+    def apply_settings_for_download(self):
+        """Push current GUI quality/settings into the download backend."""
+        self.backend.save_settings(self.collect_settings_values())
+
+    def save_settings(self):
+        self.backend.save_settings(self.collect_settings_values())
         self.settings_status.setText("Settings saved.")
 
     def refresh_auth_status(self):

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -645,14 +645,50 @@ class TidalAPI(object):
         return tracks, videos
 
     def getArtistAlbums(self, id, includeEP=False):
+        cache = getattr(self, "_artistAlbumsCache", None)
+        if cache is None:
+            self._artistAlbumsCache = {}
+            cache = self._artistAlbumsCache
+        cache_key = (str(id), bool(includeEP))
+        if cache_key in cache:
+            return list(cache[cache_key])
+
         data = self.__getItems__(f'artists/{str(id)}/albums')
         albums = list(aigpy.model.dictToModel(item, Album()) for item in data)
-        if not includeEP:
-            return albums
-
-        data = self.__getItems__(f'artists/{str(id)}/albums', {"filter": "EPSANDSINGLES"})
-        albums += list(aigpy.model.dictToModel(item, Album()) for item in data)
+        if includeEP:
+            data = self.__getItems__(f'artists/{str(id)}/albums', {"filter": "EPSANDSINGLES"})
+            albums += list(aigpy.model.dictToModel(item, Album()) for item in data)
+        cache[cache_key] = list(albums)
         return albums
+
+    def preferAtmosSearchAlbums(self, albums):
+        """Insert Atmos catalog twins for stereo album search hits when missing.
+
+        TIDAL album search often omits Dolby Atmos releases even when a stereo
+        LOSSLESS row for the same title is present.
+        """
+        if not albums:
+            return []
+
+        seen = set()
+        enriched = []
+        for album in albums:
+            album_id = str(getattr(album, "id", "") or "")
+            if album_id and album_id in seen:
+                continue
+            if album_id:
+                seen.add(album_id)
+            enriched.append(album)
+
+            if self.__hasAtmosMode__(album):
+                continue
+            twin = self.findAtmosAlbumVariant(album)
+            twin_id = str(getattr(twin, "id", "") or "") if twin is not None else ""
+            if not twin_id or twin_id in seen or twin_id == album_id:
+                continue
+            seen.add(twin_id)
+            enriched.append(twin)
+        return enriched
 
     def getArtistVideos(self, id):
         data = self.__getItems__(f'artists/{str(id)}/videos')


### PR DESCRIPTION
## Summary
Follow-up to #45 so issue #44 is fully covered.

- Album search injects Atmos catalog twins when TIDAL only returns stereo
- Playlist/mix/track downloads resolve Atmos twins (not only album/start_track)
- Artist downloads skip duplicate stereo albums when Atmos exists
- GUI applies Settings quality before download (Windows Atmos dropdown works without Save)

## Test plan
- [x] 162 unit tests OK
- [x] Live: album search shows LOW · Dolby Atmos twin
- [x] Live: stereo album/track with quality Atmos streams DOLBY_ATMOS/ec-3