### PR TITLE
Release 2026.8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,22 @@
 
 ## Unreleased
 
+## 2026.8.4.0 - 2026-08-04
+
+### Dolby Atmos catalog selection (#44)
+
+- Search quality labels show `Dolby Atmos` when `audioModes` includes `DOLBY_ATMOS` (Atmos releases often report `LOW`).
+- Album search injects matching Atmos catalog twins when TIDAL only returns the stereo row.
+- Track models retain `audioModes` from TIDAL search/catalog payloads.
+- When download quality is Atmos, stereo album/track/playlist/mix picks auto-resolve to the matching Atmos catalog twin (no Android URL required).
+- Artist downloads skip stereo albums when an Atmos twin is already in the list.
+- GUI applies current Settings (including Atmos quality) before starting downloads.
+- Album details print max quality, audio modes, and flags.
+
+### Packaging and reliability
+
 - Documented and enabled first-party PyPI installs (`pip install tidekeeper`).
 - `tidekeeper --update` and the one-line installer now install from PyPI by default.
-- Improved Dolby Atmos catalog selection (#44):
-  - Search quality labels show `Dolby Atmos` when `audioModes` includes `DOLBY_ATMOS` (Atmos releases often report `LOW`).
-  - Album search injects matching Atmos catalog twins when TIDAL only returns the stereo row.
-  - Track models retain `audioModes` from TIDAL search/catalog payloads.
-  - When download quality is Atmos, stereo album/track/playlist/mix picks auto-resolve to the matching Atmos catalog twin.
-  - Artist downloads skip stereo albums when an Atmos twin is already in the list.
-  - GUI applies current Settings (including Atmos quality) before starting downloads.
-  - Album details print max quality, audio modes, and flags.
 - Hardened track CDN downloads for reliability and stability:
   - Mismatched HTTP Range responses re-fetch fully instead of writing a truncated body.
   - Multi-segment DASH/HLS parts use per-segment resume (sequential and parallel).

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -25,7 +25,7 @@ from .environment import isTermux
 from .lang.language import *
 
 
-VERSION = '2026.7.30.0'
+VERSION = '2026.8.4.0'
 PROJECT_URL = 'https://github.com/OpenNerdz/tidekeeper'
 
 print_mutex = threading.Lock()


### PR DESCRIPTION
## Summary
- Version bump to **2026.8.4.0**
- Changelog for Atmos catalog selection (#44) and packaging/reliability work
- Enables a tagged GitHub/PyPI release so Windows users get the Atmos fix without building from main

## Test plan
- [x] Prior Atmos unit/live checks already on main
- [ ] CI green after merge
- [ ] Tag `v2026.8.4.0` after merge to trigger release assets