### PR TITLE
Reduce TIDAL API rate-limit pressure safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Reduced TIDAL API rate-limit pressure without changing successful download quality:
+  - OpenAPI no longer retries DOWNLOAD→PLAYBACK after permanent `CLIENT_NOT_ENTITLED` blocks (was 2 limited calls for Atmos misses).
+  - Atmos quality no longer probes standard playback as accidental `HI_RES`; fall through uses the configured quality priority instead.
+  - Session caches for Atmos twin albums/tracks and Atmos-unavailable track IDs.
+  - Catalog HTTP 429s apply the same adaptive backoff as playback/manifest requests.
+  - Catalog calls only join the request delay while adaptive backoff is elevated after a 429.
+  - Stream manifest resolution is single-flight across multi-thread downloads.
+
 ## 2026.8.4.0 - 2026-08-04
 
 ### Dolby Atmos catalog selection (#44)

--- a/TIDALDL-PY/tests/test_rate_limiter.py
+++ b/TIDALDL-PY/tests/test_rate_limiter.py
@@ -1,7 +1,15 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
-from tidal_dl.tidal import RequestRateLimiter
+from tidal_dl.enums import AudioQuality
+from tidal_dl.tidal import (
+    API_BASE_PRIMARY,
+    RequestRateLimiter,
+    TidalAPI,
+    TidalApiError,
+    TidalStreamUnavailable,
+)
 
 
 class AdaptiveRateLimiterTests(unittest.TestCase):
@@ -35,6 +43,102 @@ class AdaptiveRateLimiterTests(unittest.TestCase):
 
         self.assertEqual(delay, 7.0)
         sleep.assert_called_once_with(7.0)
+
+    def test_client_not_entitled_is_not_retryable_manifest_error(self):
+        api = TidalAPI()
+        error = TidalApiError("blocked", 403, ["CLIENT_NOT_ENTITLED"])
+        self.assertFalse(api.__isRetryableManifestError__(error))
+        self.assertTrue(api.__isRetryableManifestError__(
+            TidalApiError("missing", 403, ["PREREQUISITE_MISSING"])
+        ))
+
+    def test_openapi_client_not_entitled_does_not_retry_playback_usage(self):
+        api = TidalAPI()
+        error = TidalApiError("blocked", 403, ["CLIENT_NOT_ENTITLED"])
+        with mock.patch.object(api, "__getOpenApiTrackManifestOnce__", side_effect=error) as once:
+            with self.assertRaises(TidalApiError):
+                api.__getOpenApiTrackManifest__(123, ["EAC3_JOC"])
+        once.assert_called_once()
+        self.assertEqual(once.call_args.args[2], "DOWNLOAD")
+
+    def test_atmos_miss_is_cached_for_session(self):
+        api = TidalAPI()
+        with mock.patch.object(
+            api,
+            "__getOpenApiTrackManifest__",
+            side_effect=TidalApiError("blocked", 403, ["CLIENT_NOT_ENTITLED"]),
+        ) as openapi:
+            with self.assertRaises(TidalApiError):
+                api.__getAtmosStreamUrl__(999)
+            with self.assertRaises(TidalStreamUnavailable):
+                api.__getAtmosStreamUrl__(999)
+        openapi.assert_called_once()
+        self.assertIn("999", api._atmosUnavailableTrackIds)
+
+    def test_atmos_only_quality_does_not_probe_standard_hi_res(self):
+        api = TidalAPI()
+        with mock.patch.object(
+            api,
+            "__getAtmosStreamUrl__",
+            side_effect=TidalStreamUnavailable("no atmos"),
+        ), mock.patch.object(api, "__getStandardStreamUrl__") as standard:
+            with self.assertRaises(TidalStreamUnavailable):
+                api.__getAudioStreamUrlForQuality__(456, AudioQuality.Atmos)
+        standard.assert_not_called()
+
+    def test_catalog_429_applies_adaptive_penalty(self):
+        api = TidalAPI()
+        response = SimpleNamespace(
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "11"},
+            close=mock.Mock(),
+            json=mock.Mock(return_value={}),
+        )
+        success = SimpleNamespace(
+            status_code=200,
+            text='{"id":1}',
+            headers={},
+            close=mock.Mock(),
+            json=mock.Mock(return_value={"id": 1}),
+        )
+        with mock.patch.object(api.session, "get", side_effect=[response, success]), \
+             mock.patch.object(api, "__applyRateLimitPenalty__", return_value=11.0) as penalize, \
+             mock.patch("tidal_dl.tidal.time.sleep") as sleep, \
+             mock.patch("builtins.print"):
+            result = api.__getOnce__("albums/1", urlpre=API_BASE_PRIMARY)
+        self.assertEqual(result, {"id": 1})
+        penalize.assert_called_once()
+        sleep.assert_called_once_with(11.0)
+
+    def test_atmos_album_twin_cache_avoids_repeat_lookup(self):
+        api = TidalAPI()
+        stereo = SimpleNamespace(
+            id=100,
+            title="Album",
+            audioModes=["STEREO"],
+            audioQuality="LOSSLESS",
+            explicit=False,
+            numberOfTracks=10,
+            artist=SimpleNamespace(id=7, name="Artist"),
+            artists=[SimpleNamespace(id=7, name="Artist")],
+        )
+        atmos = SimpleNamespace(
+            id=200,
+            title="Album",
+            audioModes=["DOLBY_ATMOS"],
+            audioQuality="LOW",
+            explicit=False,
+            numberOfTracks=10,
+            artist=SimpleNamespace(id=7, name="Artist"),
+            artists=[SimpleNamespace(id=7, name="Artist")],
+        )
+        with mock.patch.object(api, "getArtistAlbums", return_value=[stereo, atmos]) as albums:
+            first = api.findAtmosAlbumVariant(stereo)
+            second = api.findAtmosAlbumVariant(stereo)
+        self.assertIs(first, atmos)
+        self.assertIs(second, atmos)
+        albums.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/TIDALDL-PY/tests/test_stream_cache.py
+++ b/TIDALDL-PY/tests/test_stream_cache.py
@@ -39,8 +39,15 @@ class StreamCacheTests(unittest.TestCase):
 
     def test_expired_stream_is_resolved_again(self):
         api = TidalAPI()
+        # getStreamUrlByPriority checks the cache outside and inside the resolve lock.
+        times = [
+            0.0, 0.0, 0.0,  # first resolve: outer miss, inner miss, cache store
+            STREAM_CACHE_TTL_SECONDS + 1,  # second outer: expired
+            STREAM_CACHE_TTL_SECONDS + 1,  # second inner: expired
+            STREAM_CACHE_TTL_SECONDS + 1,  # second cache store
+        ]
         with mock.patch.object(api, "__getAudioStreamUrlForQuality__", return_value=self._stream()) as resolve, \
-             mock.patch("tidal_dl.tidal.time.monotonic", side_effect=[0.0, 0.0, STREAM_CACHE_TTL_SECONDS + 1, STREAM_CACHE_TTL_SECONDS + 1]):
+             mock.patch("tidal_dl.tidal.time.monotonic", side_effect=times):
             api.getStreamUrlByPriority(123, [AudioQuality.HiFi])
             api.getStreamUrlByPriority(123, [AudioQuality.HiFi])
 

--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -111,6 +111,14 @@ class TidalAPI(object):
         self._playbackBlockedParams = set()
         self._streamCache = {}
         self._streamCacheLock = Lock()
+        # Serialize stream-manifest resolution so multi-thread downloads do not
+        # stampede playback/OpenAPI endpoints.
+        self._streamResolveLock = Lock()
+        # Session caches that cut repeat catalog / Atmos-miss traffic.
+        self._artistAlbumsCache = {}
+        self._atmosAlbumTwinCache = {}
+        self._atmosTrackTwinCache = {}
+        self._atmosUnavailableTrackIds = set()
 
     def __responseBody__(self, response):
         try:
@@ -196,6 +204,22 @@ class TidalAPI(object):
             return
         syncPlaybackRateLimiter()
         self.playbackRateLimiter.wait()
+
+    def __waitForCatalogRequestQuota__(self):
+        """Pace catalog calls only while adaptive backoff is elevated after 429s.
+
+        Normal search stays snappy; after rate limits, catalog traffic cools down
+        with the same shared limiter used for playback/manifest requests.
+        """
+        if SETTINGS.downloadDelay is False:
+            return
+        if not getattr(SETTINGS, 'adaptiveRateLimit', True):
+            return
+        syncPlaybackRateLimiter()
+        limiter = self.playbackRateLimiter
+        if limiter.effectiveInterval() <= max(limiter.minInterval, 0.0):
+            return
+        limiter.wait()
 
     def __applyRateLimitPenalty__(self, response, attempt):
         delay = self.__retryAfter__(response, attempt)
@@ -307,11 +331,16 @@ class TidalAPI(object):
                 header = {'authorization': f'Bearer {self.key.accessToken}'}
                 if playbackRequest:
                     self.__waitForStreamRequestQuota__()
+                else:
+                    # Only engages after a 429 raised the adaptive interval.
+                    self.__waitForCatalogRequestQuota__()
 
                 respond = self.session.get(url, headers=header, params=params, timeout=REQUEST_TIMEOUT)
 
                 if respond.status_code == 429:
-                    delay = self.__applyRateLimitPenalty__(respond, index) if playbackRequest else self.__retryAfter__(respond, index)
+                    # Always apply adaptive penalty (catalog and playback) so one
+                    # storm cools the whole client, not only stream endpoints.
+                    delay = self.__applyRateLimitPenalty__(respond, index)
                     if index >= RATE_LIMIT_MAX_ATTEMPTS - 1:
                         raise self.__httpError__("Get operation", respond)
                     print(f"Too many requests, automatically waiting {delay:g} seconds before retry.")
@@ -645,10 +674,7 @@ class TidalAPI(object):
         return tracks, videos
 
     def getArtistAlbums(self, id, includeEP=False):
-        cache = getattr(self, "_artistAlbumsCache", None)
-        if cache is None:
-            self._artistAlbumsCache = {}
-            cache = self._artistAlbumsCache
+        cache = self._artistAlbumsCache
         cache_key = (str(id), bool(includeEP))
         if cache_key in cache:
             return list(cache[cache_key])
@@ -768,8 +794,13 @@ class TidalAPI(object):
     def __isRetryableManifestError__(self, error):
         if not isinstance(error, TidalApiError):
             return False
+        # Permanent entitlement blocks are not fixed by switching DOWNLOAD↔PLAYBACK.
+        # Retrying doubles rate-limited OpenAPI traffic for no gain (e.g. Atmos on stereo).
+        if 'CLIENT_NOT_ENTITLED' in error.errorCodes:
+            return False
         if 'PREREQUISITE_MISSING' in error.errorCodes:
             return True
+        # Other 403/404/405 can still be usage- or format-specific.
         return error.statusCode in (403, 404, 405)
 
     def __getOpenApiTrackManifest__(self, id, formats, usages=None):
@@ -862,13 +893,25 @@ class TidalAPI(object):
         return None
 
     def __getAtmosStreamUrl__(self, id):
-        attrs = self.__getOpenApiTrackManifest__(id, ['EAC3_JOC'])
+        track_id = str(id)
+        if track_id in self._atmosUnavailableTrackIds:
+            raise TidalStreamUnavailable("Dolby Atmos stream is not available for this track.")
+
+        try:
+            attrs = self.__getOpenApiTrackManifest__(id, ['EAC3_JOC'])
+        except Exception as e:
+            if self.__isPermanentAtmosUnavailableError__(e):
+                self._atmosUnavailableTrackIds.add(track_id)
+            raise
+
         formats = attrs.get('formats') or []
         if 'EAC3_JOC' not in formats:
+            self._atmosUnavailableTrackIds.add(track_id)
             raise TidalStreamUnavailable("Dolby Atmos stream is not available for this track.")
 
         uri = attrs.get('uri') or ''
         if ',' not in uri:
+            self._atmosUnavailableTrackIds.add(track_id)
             raise TidalStreamUnavailable("Dolby Atmos manifest is empty.")
 
         xmldata = base64.b64decode(uri.split(',', 1)[1]).decode('utf-8')
@@ -882,7 +925,17 @@ class TidalAPI(object):
         ret.container = 'mp4'
         if len(ret.urls) > 0:
             ret.url = ret.urls[0]
+        self._atmosUnavailableTrackIds.discard(track_id)
         return ret
+
+    def __isPermanentAtmosUnavailableError__(self, error):
+        if isinstance(error, TidalStreamUnavailable):
+            return True
+        if not isinstance(error, TidalApiError):
+            return False
+        if 'CLIENT_NOT_ENTITLED' in error.errorCodes:
+            return True
+        return error.statusCode in (403, 404)
 
     def __getOpenApiFlacStreamUrl__(self, id, quality: AudioQuality):
         requested_formats = self.__openApiFormatsForQuality__(quality)
@@ -912,10 +965,14 @@ class TidalAPI(object):
     def __getAudioStreamUrlForQuality__(self, id, quality: AudioQuality):
         chain = []
         if quality == AudioQuality.Atmos:
+            # Atmos is OpenAPI-only. Do not probe standard playback with the
+            # accidental HI_RES mapping — that wastes a limited call and is not
+            # the next quality the user configured (use quality-priority instead).
             chain.append(lambda: self.__getAtmosStreamUrl__(id))
-        chain.append(lambda: self.__getStandardStreamUrl__(id, quality))
-        if quality in (AudioQuality.HiFi, AudioQuality.Max, AudioQuality.Master):
-            chain.append(lambda q=quality: self.__getOpenApiFlacStreamUrl__(id, q))
+        else:
+            chain.append(lambda: self.__getStandardStreamUrl__(id, quality))
+            if quality in (AudioQuality.HiFi, AudioQuality.Max, AudioQuality.Master):
+                chain.append(lambda q=quality: self.__getOpenApiFlacStreamUrl__(id, q))
 
         last_error = None
         last_stream = None
@@ -1133,25 +1190,31 @@ class TidalAPI(object):
         if cached is not None:
             return cached
 
-        lastError = None
-        requestedQuality = priority[0]
-        for index, item in enumerate(priority):
-            try:
-                stream = self.__getAudioStreamUrlForQuality__(id, item)
-                mismatch = self.__streamQualityMismatch__(stream, item)
-                if mismatch is not None:
-                    lastError = mismatch
-                    if index == len(priority) - 1:
-                        raise mismatch
-                    continue
-                stream = self.__annotateStreamFallback__(stream, requestedQuality, item, lastError)
-                self.__cacheStream__(cacheKey, stream)
-                return stream
-            except Exception as e:
-                lastError = e
-                if index == len(priority) - 1 or not self.__isManifestFallbackError__(e):
-                    raise
-        raise lastError
+        # One stream resolve at a time across multi-thread downloads.
+        with self._streamResolveLock:
+            cached = self.__getCachedStream__(cacheKey)
+            if cached is not None:
+                return cached
+
+            lastError = None
+            requestedQuality = priority[0]
+            for index, item in enumerate(priority):
+                try:
+                    stream = self.__getAudioStreamUrlForQuality__(id, item)
+                    mismatch = self.__streamQualityMismatch__(stream, item)
+                    if mismatch is not None:
+                        lastError = mismatch
+                        if index == len(priority) - 1:
+                            raise mismatch
+                        continue
+                    stream = self.__annotateStreamFallback__(stream, requestedQuality, item, lastError)
+                    self.__cacheStream__(cacheKey, stream)
+                    return stream
+                except Exception as e:
+                    lastError = e
+                    if index == len(priority) - 1 or not self.__isManifestFallbackError__(e):
+                        raise
+            raise lastError
 
     def getStreamUrl(self, id, quality: AudioQuality):
         # Share stream-manifest cache with the priority path used by downloads.
@@ -1256,6 +1319,11 @@ class TidalAPI(object):
         if self.__hasAtmosMode__(album):
             return album
 
+        album_id = str(getattr(album, "id", "") or "")
+        if album_id and album_id in self._atmosAlbumTwinCache:
+            cached = self._atmosAlbumTwinCache[album_id]
+            return album if cached is None else cached
+
         artist_id = None
         artist = getattr(album, "artist", None)
         if artist is not None and getattr(artist, "id", None) is not None:
@@ -1266,10 +1334,14 @@ class TidalAPI(object):
                     artist_id = item.id
                     break
         if artist_id is None:
+            if album_id:
+                self._atmosAlbumTwinCache[album_id] = None
             return None
 
         target_title = self.__normalizeCatalogTitle__(getattr(album, "title", None))
         if not target_title:
+            if album_id:
+                self._atmosAlbumTwinCache[album_id] = None
             return None
 
         try:
@@ -1286,6 +1358,8 @@ class TidalAPI(object):
                 continue
             matches.append(candidate)
         if not matches:
+            if album_id:
+                self._atmosAlbumTwinCache[album_id] = None
             return None
 
         def score(candidate):
@@ -1298,7 +1372,11 @@ class TidalAPI(object):
 
         best = sorted(matches, key=score)[0]
         if str(getattr(best, "id", "")) == str(getattr(album, "id", "")):
+            if album_id:
+                self._atmosAlbumTwinCache[album_id] = None
             return album
+        if album_id:
+            self._atmosAlbumTwinCache[album_id] = best
         return best
 
     def findAtmosTrackVariant(self, track: Track):
@@ -1308,9 +1386,15 @@ class TidalAPI(object):
         if self.__hasAtmosMode__(track):
             return track
 
+        track_id = str(getattr(track, "id", "") or "")
+        if track_id and track_id in self._atmosTrackTwinCache:
+            return self._atmosTrackTwinCache[track_id]
+
         album_ref = getattr(track, "album", None)
         album_id = getattr(album_ref, "id", None) if album_ref is not None else None
         if album_id is None:
+            if track_id:
+                self._atmosTrackTwinCache[track_id] = None
             return None
 
         try:
@@ -1321,6 +1405,8 @@ class TidalAPI(object):
 
         atmos_album = self.findAtmosAlbumVariant(album)
         if atmos_album is None or str(getattr(atmos_album, "id", "")) == str(album_id):
+            if track_id:
+                self._atmosTrackTwinCache[track_id] = None
             return None
 
         try:
@@ -1334,18 +1420,27 @@ class TidalAPI(object):
         target_number = getattr(track, "trackNumber", None)
         target_volume = getattr(track, "volumeNumber", None)
 
+        matched = None
         for candidate in atmos_tracks or []:
             if target_isrc and (getattr(candidate, "isrc", None) or "").strip().upper() == target_isrc:
-                return candidate
-        for candidate in atmos_tracks or []:
-            if target_number is not None and getattr(candidate, "trackNumber", None) == target_number:
-                if target_volume is None or getattr(candidate, "volumeNumber", None) == target_volume:
-                    if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
-                        return candidate
-        for candidate in atmos_tracks or []:
-            if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
-                return candidate
-        return None
+                matched = candidate
+                break
+        if matched is None:
+            for candidate in atmos_tracks or []:
+                if target_number is not None and getattr(candidate, "trackNumber", None) == target_number:
+                    if target_volume is None or getattr(candidate, "volumeNumber", None) == target_volume:
+                        if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
+                            matched = candidate
+                            break
+        if matched is None:
+            for candidate in atmos_tracks or []:
+                if self.__normalizeCatalogTitle__(getattr(candidate, "title", None)) == target_title:
+                    matched = candidate
+                    break
+
+        if track_id:
+            self._atmosTrackTwinCache[track_id] = matched
+        return matched
 
     def parseUrl(self, url):
         if "tidal.com" not in url:


### PR DESCRIPTION
## Summary
Safe reliability changes for 429s / API thrash:

- No OpenAPI DOWNLOAD→PLAYBACK retry on permanent `CLIENT_NOT_ENTITLED` (Atmos miss was 2 limited calls)
- Atmos quality no longer probes standard `HI_RES`; priority list handles fallback
- Session caches for Atmos album/track twins and Atmos-unavailable track IDs
- Catalog 429s use the same adaptive penalty as playback
- Catalog pacing only while adaptive backoff is elevated
- Single-flight stream resolve for multi-thread downloads

## Measured (live)
| Path | Before | After |
|------|--------|-------|
| Atmos,Max on stereo track | 4 | 2 |
| Atmos on Atmos track | 1 | 1 |
| Repeat Atmos miss | 1+ per try | 0 after first |

## Test plan
- [x] 168 unit tests OK
- [x] Live call-count checks above