### PR TITLE
Add ArtistID to video path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ tidekeeper -l "/path/to/downloads/failed-tracks.txt"
 Custom filename formats are supported:
 | Tokens  | Description  | Album | Track | Video | Playlist |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| {ArtistID}  | Comma separated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {ArtistID}  | Comma separated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :x:  | :white_check_mark:  | :x: |
 | {ArtistName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :x:  | :x:  | :x: |
 | {ArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
 | {ArtistsName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -203,6 +203,7 @@ def getVideoPath(video, album=None, playlist=None):
     # get artist
     artists = __fixPath__(TIDAL_API.getArtistsName(video.artists))
     artist = __fixPath__(video.artist.name) if video.artist is not None else ""
+    artistID = __fixPath__(str(video.artist.id)) if video.artist is not None else ""
 
     # explicit
     explicit = "(Explicit)" if video.explicit else ''
@@ -217,6 +218,7 @@ def getVideoPath(video, album=None, playlist=None):
         retpath = SETTINGS.getDefaultPathFormat(Type.Video)
     retpath = retpath.replace(R"{VideoNumber}", number)
     retpath = retpath.replace(R"{ArtistName}", artist)
+    retpath = retpath.replace(R"{ArtistID}", artistID)
     retpath = retpath.replace(R"{ArtistsName}", artists)
     retpath = retpath.replace(R"{VideoTitle}", title)
     retpath = retpath.replace(R"{ExplicitFlag}", explicit)


### PR DESCRIPTION
## Summary

Added ArtistID to video path

## Testing

All unit tests.

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [X] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
