### PR TITLE
Added file token options for TrackArtistID, TrackArtistName, VideoArt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Path tokens
+
+- Added `{TrackArtistID}`, `{TrackArtistName}`, `{VideoArtistID}`, and `{VideoArtistName}` for the primary artist on track and video filenames.
+- `{ArtistID}` now works in track file formats (comma-separated list of all track artist IDs).
+- Existing `{ArtistName}` (primary artist) and `{ArtistsName}` (all artists) on tracks and videos are unchanged.
+
 ## 2026.8.18.0 - 2026-08-18
 
 ### GUI

--- a/README.md
+++ b/README.md
@@ -108,12 +108,14 @@ tidekeeper -l "/path/to/downloads/failed-tracks.txt"
 Custom filename formats are supported:
 | Tokens  | Description  | Album | Track | Video | Playlist |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| {ArtistID}  | Comma separated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :x:  | :white_check_mark:  | :x: |
-| {ArtistName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :x:  | :x:  | :x: |
-| {ArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
-| {ArtistsName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {ArtistID}  | Comma separated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {ArtistName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :x: |
 | {AlbumArtistID}  | Primary artist's ID for that media | :white_check_mark:  | :x:  | :x:  | :x: |
 | {AlbumArtistName}  | Primary artist's name for that media | :white_check_mark:  | :x:  | :x:  | :x: |
+| {TrackArtistID}  | Primary artist's ID for that media | :x:  | :white_check_mark:  | :x:  | :x: |
+| {TrackArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :x:  | :x: |
+| {VideoArtistID}  | Primary artist's ID for that media | :x: | :x:  | :white_check_mark:  | :x: |
+| {VideoArtistName}  | Primary artist's name for that media | :x:  | :x:  | :white_check_mark:  | :x: |
 | {Flag}  | Quality/content flags: `M` (Master), `A` (Dolby Atmos), `E` (Explicit) | :white_check_mark:  | :x:  | :x:  | :x: |
 | {AlbumID}  |  | :white_check_mark:  | :x:  | :x:  | :x: |
 | {AlbumYear}  |  | :white_check_mark:  | :white_check_mark:  | :x:  | :x: |

--- a/README.md
+++ b/README.md
@@ -109,12 +109,14 @@ Custom filename formats are supported:
 | Tokens  | Description  | Album | Track | Video | Playlist |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | {ArtistID}  | Comma separated list of each artists' ID for that media (i.e: ```123, 456```)  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :x: |
-| {ArtistName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {ArtistName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :white_check_mark:  | :x:  | :x:  | :x: |
+| {ArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
+| {ArtistsName}  | Comma separated list of each artists' name for that media (i.e: ```ABC, DEF```)  | :x:  | :white_check_mark:  | :white_check_mark:  | :x: |
 | {AlbumArtistID}  | Primary artist's ID for that media | :white_check_mark:  | :x:  | :x:  | :x: |
 | {AlbumArtistName}  | Primary artist's name for that media | :white_check_mark:  | :x:  | :x:  | :x: |
 | {TrackArtistID}  | Primary artist's ID for that media | :x:  | :white_check_mark:  | :x:  | :x: |
 | {TrackArtistName}  | Primary artist's name for that media | :x:  | :white_check_mark:  | :x:  | :x: |
-| {VideoArtistID}  | Primary artist's ID for that media | :x: | :x:  | :white_check_mark:  | :x: |
+| {VideoArtistID}  | Primary artist's ID for that media | :x:  | :x:  | :white_check_mark:  | :x: |
 | {VideoArtistName}  | Primary artist's name for that media | :x:  | :x:  | :white_check_mark:  | :x: |
 | {Flag}  | Quality/content flags: `M` (Master), `A` (Dolby Atmos), `E` (Explicit) | :white_check_mark:  | :x:  | :x:  | :x: |
 | {AlbumID}  |  | :white_check_mark:  | :x:  | :x:  | :x: |

--- a/TIDALDL-PY/tests/test_regressions.py
+++ b/TIDALDL-PY/tests/test_regressions.py
@@ -194,6 +194,88 @@ class CliAuthPathRegressionTests(unittest.TestCase):
             for key, value in old_values.items():
                 setattr(paths.SETTINGS, key, value)
 
+    def test_track_artist_tokens_keep_primary_name_and_add_new_tokens(self):
+        old_values = {
+            "downloadPath": paths.SETTINGS.downloadPath,
+            "albumFolderFormat": paths.SETTINGS.albumFolderFormat,
+            "trackFileFormat": paths.SETTINGS.trackFileFormat,
+        }
+        try:
+            paths.SETTINGS.downloadPath = "/tmp/tidekeeper"
+            paths.SETTINGS.albumFolderFormat = "{AlbumTitle}"
+            track = self._track()
+            track.artist = self._artist("Primary/Name", 111)
+            track.artists = [self._artist("Primary/Name", 111), self._artist("Feat", 222)]
+
+            paths.SETTINGS.trackFileFormat = "{TrackNumber} - {ArtistName} - {TrackTitle}{ExplicitFlag}"
+            default_path = paths.getTrackPath(track, self._stream(), self._album())
+            self.assertTrue(default_path.endswith("01 - Primary-Name - Track.m4a"))
+
+            paths.SETTINGS.trackFileFormat = (
+                "{ArtistName}|{ArtistsName}|{ArtistID}|{TrackArtistID}|{TrackArtistName}"
+            )
+            token_path = paths.getTrackPath(track, self._stream(), self._album())
+            self.assertTrue(
+                token_path.endswith("Primary-Name|Primary-Name, Feat|111, 222|111|Primary-Name.m4a")
+            )
+        finally:
+            for key, value in old_values.items():
+                setattr(paths.SETTINGS, key, value)
+
+    def test_video_artist_tokens_keep_primary_name_and_add_new_tokens(self):
+        old_values = {
+            "downloadPath": paths.SETTINGS.downloadPath,
+            "videoFileFormat": paths.SETTINGS.videoFileFormat,
+        }
+        try:
+            paths.SETTINGS.downloadPath = "/tmp/tidekeeper"
+            video = self._video()
+            video.artist = self._artist("Primary/Name", 111)
+            video.artists = [self._artist("Primary/Name", 111), self._artist("Feat", 222)]
+
+            paths.SETTINGS.videoFileFormat = "{VideoNumber} - {ArtistName} - {VideoTitle}{ExplicitFlag}"
+            default_path = paths.getVideoPath(video)
+            self.assertTrue(default_path.endswith("01 - Primary-Name - Video.mp4"))
+
+            paths.SETTINGS.videoFileFormat = (
+                "{ArtistName}|{ArtistsName}|{ArtistID}|{VideoArtistID}|{VideoArtistName}"
+            )
+            token_path = paths.getVideoPath(video)
+            self.assertTrue(
+                token_path.endswith("Primary-Name|Primary-Name, Feat|111, 222|111|Primary-Name.mp4")
+            )
+        finally:
+            for key, value in old_values.items():
+                setattr(paths.SETTINGS, key, value)
+
+    def test_track_and_video_primary_artist_tokens_omit_missing_fields(self):
+        old_values = {
+            "downloadPath": paths.SETTINGS.downloadPath,
+            "albumFolderFormat": paths.SETTINGS.albumFolderFormat,
+            "trackFileFormat": paths.SETTINGS.trackFileFormat,
+            "videoFileFormat": paths.SETTINGS.videoFileFormat,
+        }
+        try:
+            paths.SETTINGS.downloadPath = "/tmp/tidekeeper"
+            paths.SETTINGS.albumFolderFormat = "{AlbumTitle}"
+            paths.SETTINGS.trackFileFormat = "{TrackArtistID}/{TrackArtistName}/{TrackTitle}"
+            paths.SETTINGS.videoFileFormat = "{VideoArtistID}/{VideoArtistName}/{VideoTitle}"
+
+            track = self._track()
+            track.artist = self._artist(None, None)
+            track_path = paths.getTrackPath(track, self._stream(), self._album())
+            self.assertNotIn("None", track_path)
+            self.assertTrue(track_path.endswith("//Track.m4a"))
+
+            video = self._video()
+            video.artist = self._artist(None, None)
+            video_path = paths.getVideoPath(video)
+            self.assertNotIn("None", video_path)
+            self.assertTrue(video_path.endswith("//Video.mp4"))
+        finally:
+            for key, value in old_values.items():
+                setattr(paths.SETTINGS, key, value)
+
     def test_get_album_converts_each_artist_to_model(self):
         api = TidalAPI()
         payload = {

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -151,10 +151,9 @@ def getTrackPath(track, stream, album=None, playlist=None):
     # artist
     artists = __fixPath__(TIDAL_API.getArtistsName(track.artists))
     artistID = __fixPath__(TIDAL_API.getArtistsID(track.artists))
-
     primary_artist = getattr(track, 'artist', None)
-    trackArtistID = __tokenValue__(getattr(primary_artist, 'id', None))
-    trackArtistName = __tokenValue__(getattr(primary_artist, 'name', None))
+    trackArtistID = __fixPath__(__tokenValue__(getattr(primary_artist, 'id', None)))
+    trackArtistName = __fixPath__(__tokenValue__(getattr(primary_artist, 'name', None)))
 
     # title
     title = __fixPath__(track.title)
@@ -176,7 +175,8 @@ def getTrackPath(track, stream, album=None, playlist=None):
         retpath = SETTINGS.getDefaultPathFormat(Type.Track)
     hasStreamIdentifier = __hasStreamIdentifierToken__(retpath)
     retpath = retpath.replace(R"{TrackNumber}", number)
-    retpath = retpath.replace(R"{ArtistName}", artists)
+    retpath = retpath.replace(R"{ArtistName}", trackArtistName)
+    retpath = retpath.replace(R"{ArtistsName}", artists)
     retpath = retpath.replace(R"{ArtistID}", artistID)
     retpath = retpath.replace(R"{TrackArtistID}", trackArtistID)
     retpath = retpath.replace(R"{TrackArtistName}", trackArtistName)
@@ -208,12 +208,10 @@ def getVideoPath(video, album=None, playlist=None):
 
     # get artist
     artists = __fixPath__(TIDAL_API.getArtistsName(video.artists))
-    artist = __fixPath__(video.artist.name) if video.artist is not None else ""
     artistID = __fixPath__(TIDAL_API.getArtistsID(video.artists))
-
     primary_artist = getattr(video, 'artist', None)
-    videoArtistID = __tokenValue__(getattr(primary_artist, 'id', None))
-    videoArtistName = __tokenValue__(getattr(primary_artist, 'name', None))
+    videoArtistID = __fixPath__(__tokenValue__(getattr(primary_artist, 'id', None)))
+    videoArtistName = __fixPath__(__tokenValue__(getattr(primary_artist, 'name', None)))
 
     # explicit
     explicit = "(Explicit)" if video.explicit else ''
@@ -227,8 +225,9 @@ def getVideoPath(video, album=None, playlist=None):
     if retpath is None or len(retpath) <= 0:
         retpath = SETTINGS.getDefaultPathFormat(Type.Video)
     retpath = retpath.replace(R"{VideoNumber}", number)
-    retpath = retpath.replace(R"{ArtistName}", artists)
+    retpath = retpath.replace(R"{ArtistName}", videoArtistName)
     retpath = retpath.replace(R"{ArtistID}", artistID)
+    retpath = retpath.replace(R"{ArtistsName}", artists)
     retpath = retpath.replace(R"{VideoArtistID}", videoArtistID)
     retpath = retpath.replace(R"{VideoArtistName}", videoArtistName)
     retpath = retpath.replace(R"{VideoTitle}", title)

--- a/TIDALDL-PY/tidal_dl/paths.py
+++ b/TIDALDL-PY/tidal_dl/paths.py
@@ -150,7 +150,11 @@ def getTrackPath(track, stream, album=None, playlist=None):
 
     # artist
     artists = __fixPath__(TIDAL_API.getArtistsName(track.artists))
-    artist = __fixPath__(track.artist.name) if track.artist is not None else ""
+    artistID = __fixPath__(TIDAL_API.getArtistsID(track.artists))
+
+    primary_artist = getattr(track, 'artist', None)
+    trackArtistID = __tokenValue__(getattr(primary_artist, 'id', None))
+    trackArtistName = __tokenValue__(getattr(primary_artist, 'name', None))
 
     # title
     title = __fixPath__(track.title)
@@ -172,8 +176,10 @@ def getTrackPath(track, stream, album=None, playlist=None):
         retpath = SETTINGS.getDefaultPathFormat(Type.Track)
     hasStreamIdentifier = __hasStreamIdentifierToken__(retpath)
     retpath = retpath.replace(R"{TrackNumber}", number)
-    retpath = retpath.replace(R"{ArtistName}", artist)
-    retpath = retpath.replace(R"{ArtistsName}", artists)
+    retpath = retpath.replace(R"{ArtistName}", artists)
+    retpath = retpath.replace(R"{ArtistID}", artistID)
+    retpath = retpath.replace(R"{TrackArtistID}", trackArtistID)
+    retpath = retpath.replace(R"{TrackArtistName}", trackArtistName)
     retpath = retpath.replace(R"{TrackTitle}", title)
     retpath = retpath.replace(R"{ExplicitFlag}", explicit)
     retpath = retpath.replace(R"{AlbumYear}", year)
@@ -205,6 +211,10 @@ def getVideoPath(video, album=None, playlist=None):
     artist = __fixPath__(video.artist.name) if video.artist is not None else ""
     artistID = __fixPath__(TIDAL_API.getArtistsID(video.artists))
 
+    primary_artist = getattr(video, 'artist', None)
+    videoArtistID = __tokenValue__(getattr(primary_artist, 'id', None))
+    videoArtistName = __tokenValue__(getattr(primary_artist, 'name', None))
+
     # explicit
     explicit = "(Explicit)" if video.explicit else ''
 
@@ -217,9 +227,10 @@ def getVideoPath(video, album=None, playlist=None):
     if retpath is None or len(retpath) <= 0:
         retpath = SETTINGS.getDefaultPathFormat(Type.Video)
     retpath = retpath.replace(R"{VideoNumber}", number)
-    retpath = retpath.replace(R"{ArtistName}", artist)
+    retpath = retpath.replace(R"{ArtistName}", artists)
     retpath = retpath.replace(R"{ArtistID}", artistID)
-    retpath = retpath.replace(R"{ArtistsName}", artists)
+    retpath = retpath.replace(R"{VideoArtistID}", videoArtistID)
+    retpath = retpath.replace(R"{VideoArtistName}", videoArtistName)
     retpath = retpath.replace(R"{VideoTitle}", title)
     retpath = retpath.replace(R"{ExplicitFlag}", explicit)
     retpath = retpath.replace(R"{VideoYear}", year)


### PR DESCRIPTION
Added file token options for TrackArtistID, TrackArtistName, VideoArtistID, and VideoArtistName

## Summary

Commit 2899c5b removed the ability for AlbumArtistID style tokens for Video file paths in favour of aligning the video token handling to match album token handling.

I've re-added said functionality whilst refactoring a few of the token handling bits such that now the terminology is consistent across Albums, Tracks, and Videos.

## Testing
All unit tests - no problems.

## Checklist

- [X] The change is focused and does not include unrelated refactoring.
- [ ] Tests cover new behavior or regressions where practical.
- [X] Documentation is updated when user-facing behavior changes.
- [X] Logs, screenshots, and fixtures contain no tokens or personal data.
- [X] Existing `tidal-dl` compatibility is preserved where practical.
