### PR TITLE
fix: process GUI queue items added during an active download

### DIFF
--- a/TIDALDL-PY/tests/test_gui_download_worker.py
+++ b/TIDALDL-PY/tests/test_gui_download_worker.py
@@ -1,0 +1,114 @@
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+
+
+def _install_pyside_stub():
+    if "PySide6.QtCore" in sys.modules:
+        return
+    qtcore = ModuleType("PySide6.QtCore")
+
+    class _Signal:
+        def __init__(self, *args, **kwargs):
+            self._slots = []
+
+        def emit(self, *args, **kwargs):
+            for slot in self._slots:
+                slot(*args, **kwargs)
+
+        def connect(self, slot, *args, **kwargs):
+            self._slots.append(slot)
+
+    class _QObject:
+        pass
+
+    class _QRunnable:
+        def setAutoDelete(self, *args, **kwargs):
+            pass
+
+    def _Slot(*args, **kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    qtcore.QObject = _QObject
+    qtcore.QRunnable = _QRunnable
+    qtcore.Signal = _Signal
+    qtcore.Slot = _Slot
+    pyside = ModuleType("PySide6")
+    pyside.QtCore = qtcore
+    sys.modules["PySide6"] = pyside
+    sys.modules["PySide6.QtCore"] = qtcore
+
+
+class RecordingBackend:
+    def __init__(self, on_download=None):
+        self.downloaded = []
+        self._on_download = on_download
+
+    def download(self, item, log, progress=None):
+        self.downloaded.append(item.title)
+        if self._on_download:
+            self._on_download(item)
+
+
+class DownloadWorkerQueueTests(unittest.TestCase):
+    def setUp(self):
+        _install_pyside_stub()
+        from tidal_dl.gui_app.workers import DownloadWorker
+
+        self.DownloadWorker = DownloadWorker
+
+    def test_worker_picks_up_items_added_during_run(self):
+        first = SimpleNamespace(title="Album One")
+        second = SimpleNamespace(title="Album Two")
+        extra = []
+
+        def on_download(item):
+            if item.title == "Album One":
+                extra.append(second)
+
+        backend = RecordingBackend(on_download)
+        worker = self.DownloadWorker(backend, [first])
+        worker.more_items = lambda: list(extra)
+        worker.run()
+
+        self.assertEqual(backend.downloaded, ["Album One", "Album Two"])
+
+    def test_worker_cancel_does_not_start_items_added_during_run(self):
+        first = SimpleNamespace(title="Album One")
+        second = SimpleNamespace(title="Album Two")
+        extra = []
+        worker_holder = {}
+
+        def on_download(item):
+            worker_holder["worker"].cancel()
+            extra.append(second)
+
+        backend = RecordingBackend(on_download)
+        worker = self.DownloadWorker(backend, [first])
+        worker.more_items = lambda: list(extra)
+        worker_holder["worker"] = worker
+        worker.run()
+
+        self.assertEqual(backend.downloaded, ["Album One"])
+
+    def test_worker_without_more_items_keeps_original_snapshot(self):
+        first = SimpleNamespace(title="Album One")
+        backend = RecordingBackend()
+        worker = self.DownloadWorker(backend, [first])
+        worker.run()
+        self.assertEqual(backend.downloaded, ["Album One"])
+
+    def test_worker_does_not_redownload_item_still_listed_as_queued(self):
+        first = SimpleNamespace(title="Album One")
+        backend = RecordingBackend()
+        worker = self.DownloadWorker(backend, [first])
+        worker.more_items = lambda: [first]
+        worker.run()
+        self.assertEqual(backend.downloaded, ["Album One"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/TIDALDL-PY/tests/test_gui_queue.py
+++ b/TIDALDL-PY/tests/test_gui_queue.py
@@ -76,6 +76,44 @@ class GuiQueueTests(unittest.TestCase):
         self.window.start_queue_download()
         self.assertEqual(started, [queued])
 
+    def test_live_queued_items_ignore_active_failed_and_done(self):
+        done = self.SearchItem(self.Type.Track, "Done", "", "", "1", "", SimpleNamespace(id=1), status="Done")
+        failed = self.SearchItem(self.Type.Track, "Failed", "", "", "2", "", SimpleNamespace(id=2), status="Failed")
+        downloading = self.SearchItem(self.Type.Track, "Downloading", "", "", "3", "", SimpleNamespace(id=3), status="Downloading")
+        queued = self.SearchItem(self.Type.Track, "Queued", "", "", "4", "", SimpleNamespace(id=4), status="Queued")
+        self.window.queue = [done, failed, downloading, queued]
+        self.assertEqual(self.window._live_queued_items(), [queued])
+
+    def test_start_downloads_asks_worker_for_items_added_later(self):
+        queued = self.SearchItem(self.Type.Track, "Queued", "", "", "3", "", SimpleNamespace(id=3), status="Queued")
+        captured = {}
+
+        class FakeWorker:
+            def __init__(self, backend, items, more_items=None):
+                captured["items"] = list(items)
+                captured["more_items"] = more_items
+                self.signals = SimpleNamespace(
+                    log=SimpleNamespace(connect=lambda *_: None),
+                    item_status=SimpleNamespace(connect=lambda *_: None),
+                    item_progress=SimpleNamespace(connect=lambda *_: None),
+                    result=SimpleNamespace(connect=lambda *_: None),
+                    error=SimpleNamespace(connect=lambda *_: None),
+                    finished=SimpleNamespace(connect=lambda *_: None),
+                )
+
+        self.window.start_worker = lambda worker: None
+        import tidal_dl.gui_app.main_window as main_window
+
+        original = main_window.DownloadWorker
+        main_window.DownloadWorker = FakeWorker
+        try:
+            self.window.start_downloads([queued])
+        finally:
+            main_window.DownloadWorker = original
+
+        self.assertEqual(captured["items"], [queued])
+        self.assertEqual(captured["more_items"], self.window._live_queued_items)
+
     def test_device_login_poll_ignores_preexisting_token(self):
         from tidal_dl.gui_app.backend import AuthStatus
 

--- a/TIDALDL-PY/tidal_dl/gui_app/main_window.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/main_window.py
@@ -997,6 +997,9 @@ class MainWindow(QMainWindow):
     def pending_queue_items(self) -> List[SearchItem]:
         return [item for item in self.queue if item.status not in ("Done", "Downloading")]
 
+    def _live_queued_items(self) -> List[SearchItem]:
+        return [item for item in list(self.queue) if (item.status or "Queued") == "Queued"]
+
     def failed_queue_items(self) -> List[SearchItem]:
         return [item for item in self.queue if item.status == "Failed"]
 
@@ -1039,7 +1042,7 @@ class MainWindow(QMainWindow):
         self.update_action_states()
         self._set_queue_message(f"Downloading {self._plural(len(items), 'item')}…")
         self.download_log.append("Starting downloads")
-        worker = DownloadWorker(self.backend, items)
+        worker = DownloadWorker(self.backend, items, more_items=self._live_queued_items)
         self.download_worker = worker
         worker.signals.log.connect(self.append_download_log)
         worker.signals.item_status.connect(self._set_queue_item_status)

--- a/TIDALDL-PY/tidal_dl/gui_app/workers.py
+++ b/TIDALDL-PY/tidal_dl/gui_app/workers.py
@@ -160,39 +160,59 @@ class ItemProgressReporter:
 
 
 class DownloadWorker(QRunnable):
-    def __init__(self, backend, items):
+    def __init__(self, backend, items, more_items=None):
         super().__init__()
         self.setAutoDelete(False)
         self.backend = backend
         self.items = items
+        self.more_items = more_items
         self.signals = WorkerSignals()
         self._cancelled = False
 
     def cancel(self):
         self._cancelled = True
 
+    def _next_items(self, processed):
+        extra = self.more_items() if self.more_items else []
+        return [item for item in extra if id(item) not in processed]
+
     @Slot()
     def run(self):
         failed = []
         cancelled = False
+        processed = set()
         try:
-            for item in self.items:
-                if self._cancelled:
-                    cancelled = True
-                    self.signals.item_status.emit(item, "Cancelled")
-                    continue
-                self.signals.item_status.emit(item, "Downloading")
-                self.signals.log.emit(f"Starting {item.title}\n")
-                reporter = ItemProgressReporter(item, self.signals.item_progress.emit)
-                try:
-                    self.backend.download(item, self.signals.log.emit, progress=reporter)
-                except Exception as exc:
-                    failed.append(item.title)
-                    self.signals.item_status.emit(item, "Failed")
-                    self.signals.log.emit(f"Failed {item.title}: {exc}\n")
-                    continue
-                self.signals.item_status.emit(item, "Done")
-                self.signals.log.emit(f"Finished {item.title}\n")
+            items = list(self.items)
+            idx = 0
+            while True:
+                while idx < len(items):
+                    item = items[idx]
+                    idx += 1
+                    if id(item) in processed:
+                        continue
+                    processed.add(id(item))
+                    if self._cancelled:
+                        cancelled = True
+                        self.signals.item_status.emit(item, "Cancelled")
+                        continue
+                    self.signals.item_status.emit(item, "Downloading")
+                    self.signals.log.emit(f"Starting {item.title}\n")
+                    reporter = ItemProgressReporter(item, self.signals.item_progress.emit)
+                    try:
+                        self.backend.download(item, self.signals.log.emit, progress=reporter)
+                    except Exception as exc:
+                        failed.append(item.title)
+                        self.signals.item_status.emit(item, "Failed")
+                        self.signals.log.emit(f"Failed {item.title}: {exc}\n")
+                        continue
+                    self.signals.item_status.emit(item, "Done")
+                    self.signals.log.emit(f"Finished {item.title}\n")
+                if cancelled:
+                    break
+                extra = self._next_items(processed)
+                if not extra:
+                    break
+                items.extend(extra)
             if cancelled:
                 self.signals.log.emit("Remaining downloads cancelled.\n")
             if failed:
@@ -202,7 +222,7 @@ class DownloadWorker(QRunnable):
                     f"{len(failed)} download{'s' if len(failed) != 1 else ''} failed: {shown}{more}"
                 )
             elif not cancelled:
-                self.signals.result.emit(self.items)
+                self.signals.result.emit(items)
         except Exception as exc:
             self.signals.error.emit(str(exc))
         finally:


### PR DESCRIPTION
## Summary
- The GUI download worker now keeps taking newly queued items while a run is already in progress.
- Adding more links during an active download no longer waits for you to click Start again.
- Cancel still stops the current run and does not start those later items.

## Motivation
Closes #56

## Test Plan
- [x] `python -m unittest tests.test_gui_download_worker` (RED then GREEN)
- [x] Sabotage run: ignoring `more_items` makes the new pickup test fail
- [x] `python -m unittest discover -s tests` (234 tests, 9 GUI skips without PySide6)
- [x] `python -m compileall -q tidal_dl tests`

## Notes for Reviewers
Failed items are not retried automatically. Click Start or Retry failed for those.