### PR TITLE
Fix stale media retries and release 2026.9.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, working]
     tags: ["v*"]
   pull_request:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Reliability
 
+- Failed stream replacements cannot cause retries to reuse an old file of the same size.
+
 - Interrupted downloads no longer mix segments from a different stream, and completed files are skipped only with a matching checksum receipt.
 - Truncated FLACs, failed video remuxes, and videos that ignore “Skip existing files” are no longer treated as successful.
 - A finished `.download` sidecar that gets HTTP 416 is promoted instead of failing the retry.
@@ -24,7 +26,6 @@
 
 - CLI startup regression tests use a real isolated configuration directory and verify file logging.
 - Development uses `working`, with verified changes merged into `main` before tagging releases.
-
 - Tag releases now run CI, then build, then publish through a reusable workflow instead of a `GITHUB_TOKEN` release event that GitHub would ignore.
 - Local `build.sh` installs the GUI extra and runs tests before building executables.
 - Current credential and queue filenames are ignored by git and Docker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2026.9.5.0 - 2026-09-05
+
 ### Reliability
 
 - Interrupted downloads no longer mix segments from a different stream, and completed files are skipped only with a matching checksum receipt.
@@ -19,6 +21,9 @@
 - Settings and account controls are locked during an active download; closing the window cancels the transfer first.
 
 ### Packaging
+
+- CLI startup regression tests use a real isolated configuration directory and verify file logging.
+- Development uses `working`, with verified changes merged into `main` before tagging releases.
 
 - Tag releases now run CI, then build, then publish through a reusable workflow instead of a `GITHUB_TOKEN` release event that GitHub would ignore.
 - Local `build.sh` installs the GUI extra and runs tests before building executables.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ python -m pip install --upgrade pip
 python -m pip install -e .
 ```
 
+## Branches
+
+The repository keeps `main` and `working`. Add features and fixes on `working`
+and open a pull request from `working` into `main` after local checks pass.
+Merge only after CI and all platform builds succeed, and retain `working` for
+subsequent development.
+
 ## Checks
 
 Run these before opening a pull request:

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -38,12 +38,21 @@ Keep `TIDALDL-PY/setup.py` `install_requires` aligned with
 Build outputs are written under `TIDALDL-PY/dist` (Python distributions and
 PyInstaller work) and `TIDALDL-PY/exe` (terminal and GUI executables).
 
+## Branch workflow
+
+Keep exactly two branches in `OpenNerdz/tidekeeper`: `main` for verified releases
+and `working` for new features and fixes. Start changes from an up-to-date
+`working`, push there, and verify CI and all platform builds before merging to
+`main`. Keep `working` after merging and fast-forward it to `main` when needed.
+Delete obsolete branches only after confirming their commits are merged.
+
 ## Release checklist
 
 1. Update the version in `TIDALDL-PY/tidal_dl/printf.py` (format `YYYY.M.D.N`).
 2. Move `CHANGELOG.md` entries from Unreleased into a new version section.
 3. Run the local development checks and the test suite.
-4. Push to `main` and confirm GitHub Actions CI passes.
+4. Push to `working` and confirm GitHub Actions CI and all platform builds pass.
+   Merge `working` into `main`, then confirm the checks on `main` pass.
 5. Confirm the GitHub `pypi` environment exists and the `PYPI_API_TOKEN` repository
    secret is set (PyPI API token with upload rights for project `tidekeeper`).
    Optional: also register a trusted publisher on PyPI for OIDC fallback

--- a/TIDALDL-PY/tests/test_audit_reliability.py
+++ b/TIDALDL-PY/tests/test_audit_reliability.py
@@ -80,6 +80,25 @@ class ReliabilityTests(unittest.TestCase):
         self.assertTrue(ok, message)
         self.assertEqual(Path(path).read_bytes(), b'NEWDATA')
 
+    def test_failed_changed_stream_does_not_reuse_old_output_on_retry(self):
+        for segmented in (False, True):
+            with self.subTest(segmented=segmented):
+                path = str(self.root / ('segmented' if segmented else 'single'))
+                Path(path).write_bytes(b'OLD-DATA')
+                urls = ['https://cdn.invalid/new0']
+                if segmented:
+                    urls.append('https://cdn.invalid/new1')
+                error = requests.HTTPError('404', response=Response(status=404))
+                with mock.patch.object(download, '__httpRequest__', side_effect=error):
+                    ok, _ = download.__downloadUrls__(urls, path, probeSize=False, expectedSize=8)
+                self.assertFalse(ok)
+                self.assertEqual(Path(path).read_bytes(), b'OLD-DATA')
+                responses = [Response(b'NEW-'), Response(b'DATA')] if segmented else [Response(b'NEW-DATA')]
+                with mock.patch.object(download, '__httpRequest__', side_effect=responses):
+                    ok, message = download.__downloadUrls__(urls, path, probeSize=False, expectedSize=8)
+                self.assertTrue(ok, message)
+                self.assertEqual(Path(path).read_bytes(), b'NEW-DATA')
+
     def test_signed_urls_are_hashed_on_disk(self):
         path = str(self.root / 'part')
         prepare_transfer(path, ['https://cdn.invalid/file?signature=dummy-secret'])

--- a/TIDALDL-PY/tests/test_cli_ui.py
+++ b/TIDALDL-PY/tests/test_cli_ui.py
@@ -1,4 +1,6 @@
 import io
+import logging
+from pathlib import Path
 import sys
 import tempfile
 import unittest
@@ -26,6 +28,19 @@ class CliUiTests(unittest.TestCase):
         """
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
+        root_logger = logging.getLogger()
+        original_handlers = list(root_logger.handlers)
+        original_level = root_logger.level
+
+        def restore_logging():
+            for handler in list(root_logger.handlers):
+                if handler not in original_handlers:
+                    root_logger.removeHandler(handler)
+                    handler.close()
+            root_logger.setLevel(original_level)
+
+        # Close log files before removing the temporary config directory.
+        self.addCleanup(restore_logging)
         PATHS.homePathOverride = tmpdir.name
         self._restoreGlobalSettings()
         return tmpdir.name
@@ -233,16 +248,15 @@ class CliUiTests(unittest.TestCase):
         mock_choices.assert_not_called()
 
     def test_sys_argvs_enable_entering_while_loop(self):
-        self._restoreGlobalSettings()
-        with mock.patch("sys.argv", ["tidekeeper", "-c", "/home/user/tidekeeper/config"]):
-            with mock.patch("tidal_dl.os.path.isdir") as mock_isdir:
-                mock_isdir.return_value = True
-                with mock.patch("tidal_dl.loginByWeb"):
-                    with mock.patch("tidal_dl.Printf.choices") as mock_choices:
-                        mock_choices.side_effect = KeyboardInterrupt
-                        with self.assertRaises(KeyboardInterrupt):
-                            tidal_dl.main()
-        mock_choices.assert_called()
+        config_home = self._isolateConfigHome()
+        with mock.patch("sys.argv", ["tidekeeper", "-c", config_home]), \
+             mock.patch("tidal_dl.loginByWeb"), \
+             mock.patch("tidal_dl.Printf.choices", side_effect=KeyboardInterrupt) as choices:
+            with self.assertRaises(KeyboardInterrupt):
+                tidal_dl.main()
+        choices.assert_called()
+        self.assertEqual(PATHS.__getHomePath__(), config_home)
+        self.assertTrue(Path(PATHS.getLogPath()).is_file())
 
 
 if __name__ == "__main__":

--- a/TIDALDL-PY/tests/test_download_backend.py
+++ b/TIDALDL-PY/tests/test_download_backend.py
@@ -235,6 +235,7 @@ class DownloadBackendTests(unittest.TestCase):
         download.prepare_transfer(str(output_file), ["https://example.invalid/media.bin"])
         payload = b"already-downloaded-bytes"
         output_file.write_bytes(payload)
+        download.complete_transfer(str(output_file))
 
         with mock.patch.object(download, "__httpRequest__") as request, \
              mock.patch.object(download, "__remoteSize__", return_value=len(payload)):

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -27,7 +27,7 @@ from .decryption import *
 from .printf import *
 from .tidal import *
 from .manifests import hls_segments
-from .transfer_state import prepare_transfer, audio_identity, video_identity, record_completion, is_completed
+from .transfer_state import prepare_transfer, complete_transfer, audio_identity, video_identity, record_completion, is_completed
 from .runtime import run_process, redact
 
 
@@ -555,6 +555,7 @@ def __downloadUrls__(
                 expectedSize=totalSize,
                 reuseExisting=source_matches,
             )
+            complete_transfer(outputPath)
             return True, ''
         except DownloadCancelled:
             raise
@@ -604,6 +605,7 @@ def __downloadUrls__(
                     raise
 
         __concatenateFiles__(partPaths, outputPath, expectedSize=totalSize)
+        complete_transfer(outputPath)
         __removeDir__(partsDir)
         return True, ''
     except DownloadCancelled:

--- a/TIDALDL-PY/tidal_dl/printf.py
+++ b/TIDALDL-PY/tidal_dl/printf.py
@@ -27,7 +27,7 @@ from .environment import isTermux
 from .lang.language import *
 
 
-VERSION = '2026.9.4.0'
+VERSION = '2026.9.5.0'
 PROJECT_URL = 'https://github.com/OpenNerdz/tidekeeper'
 
 print_mutex = threading.Lock()

--- a/TIDALDL-PY/tidal_dl/transfer_state.py
+++ b/TIDALDL-PY/tidal_dl/transfer_state.py
@@ -27,18 +27,28 @@ def _read(path):
 
 
 def prepare_transfer(path, urls):
+    """Prepare resumable parts; return whether the assembled output is reusable."""
     # Include the complete URLs: query parameters can select different media.
     # A refreshed signature may restart a transfer, but must never mix streams.
     identity = hashlib.sha256(json.dumps(list(urls)).encode()).hexdigest()
     marker = path + '.source.json'
-    matches = _read(marker).get('source') == identity
+    state = _read(marker)
+    matches = state.get('source') == identity
     if not matches:
         Path(path + '.download').unlink(missing_ok=True)
         parts = Path(path + '.parts')
         if parts.exists():
             shutil.rmtree(parts)
-        _atomicWrite(marker, json.dumps({'source': identity}))
-    return matches
+        _atomicWrite(marker, json.dumps({'source': identity, 'complete': False}))
+    return matches and state.get('complete') is True
+
+
+def complete_transfer(path):
+    """Mark the assembled output only after it has been successfully replaced."""
+    marker = path + '.source.json'
+    state = _read(marker)
+    state['complete'] = True
+    _atomicWrite(marker, json.dumps(state))
 
 
 def audio_identity(stream):


### PR DESCRIPTION
A failed replacement download could leave an old file marked as belonging to the new stream. On retry, matching file sizes caused the old bytes to be accepted. Mark assembled transfers complete only after successful replacement, while preserving resumable partial files. Regression coverage reproduces both single-file and segmented failures.

Also fix the CLI startup test that mocked a nonexistent configuration directory, close temporary logging handlers, run platform builds on `working`, and document the two-branch workflow. Prepare version 2026.9.5.0 with the previously merged download-integrity and GUI reliability updates.

Validation: 271 tests passed with Qt installed, including the new regression that failed before the fix. Ruff, compilation, installer syntax, all three CLI entry points, GUI screenshot capture, sdist/wheel builds, and strict Twine metadata checks passed locally. GitHub matrix and platform builds must pass before merge.
